### PR TITLE
Simplified and Accessible Path

### DIFF
--- a/packages/core/src/path.spec.ts
+++ b/packages/core/src/path.spec.ts
@@ -49,4 +49,22 @@ describe('path', () => {
       expect(Path.of('foo', 0, 'bar').length).toEqual(3);
     });
   });
+
+  describe('set', () => {
+    test('set root', () => expect(Path.of().set('root', { foo: 'baz' })).toEqual({ foo: 'baz' }));
+
+    test('creates necessary nested objects', () => expect(Path.of(0, 'array', 1, 'name').set([], 'name')).toEqual([{ array: [undefined, { name: 'name' }] }]));
+
+    test("doesn't replace root object with array", () =>
+      expect(Path.of(0, 'array', 1, 'name').set({}, 'name')).toEqual({ 0: { array: [undefined, { name: 'name' }] } }));
+
+    test('creates root object if necessary', () =>
+      expect(Path.of(0, 'array', 1, 'name').set(undefined, 'name')).toEqual([{ array: [undefined, { name: 'name' }] }]));
+  });
+
+  describe('unset', () => {
+    test('deletes property when setting undefined value', () => expect(Path.of('name').unset({ name: 'name' })).toEqual({}));
+
+    test("delete doesn't create intermediate objects", () => expect(Path.of('nested', 'name').unset({})).toEqual({}));
+  });
 });

--- a/packages/core/src/path.spec.ts
+++ b/packages/core/src/path.spec.ts
@@ -18,7 +18,7 @@ describe('path', () => {
     ).toEqual('$["@foo"].a5["http://xmlns.com/foaf/0.1/name"]'));
 
   describe('of', () => {
-    test('equal to path constructed by builder', () => expect(Path.of('$', 0, 'foo')).toEqual(index(0).property('foo')));
+    test('equal to path constructed by builder', () => expect(Path.of(0, 'foo')).toEqual(index(0).property('foo')));
 
     test('without root', () => expect(Path.of(0, 'foo')).toEqual(index(0).property('foo')));
 

--- a/packages/core/src/path.spec.ts
+++ b/packages/core/src/path.spec.ts
@@ -1,4 +1,4 @@
-import { property, Path, index, ROOT } from './path';
+import { property, Path, index, ROOT, PathComponent } from './path';
 
 describe('path', () => {
   test('toJSON', () =>
@@ -23,5 +23,30 @@ describe('path', () => {
     test('without root', () => expect(Path.of(0, 'foo')).toEqual(index(0).property('foo')));
 
     test('alias for root', () => expect(Path.of()).toEqual(ROOT));
+  });
+
+  describe('iterable path', () => {
+    test('use path in for..of', () => {
+      const components: PathComponent[] = [];
+      for (const component of Path.of(0, 'foo', 'bar')) {
+        components.push(component);
+      }
+      expect(components).toEqual([0, 'foo', 'bar']);
+    });
+
+    test('use path in Array.from', () => {
+      expect(Array.from(Path.of(0, 'foo', 'bar'))).toEqual([0, 'foo', 'bar']);
+    });
+
+    test('Path.get', () => {
+      const path = Path.of('foo', 0, 'bar');
+      expect(path.get(0)).toEqual('foo');
+      expect(path.get(1)).toEqual(0);
+      expect(path.get(2)).toEqual('bar');
+    });
+
+    test('Path.length', () => {
+      expect(Path.of('foo', 0, 'bar').length).toEqual(3);
+    });
   });
 });

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -1,6 +1,6 @@
 export type PathComponent = number | string;
 
-const identifier = /^[a-zA-Z_]+[a-zA-Z0-9_]*$/;
+const identifier = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 export class Path {
   private readonly path: PathComponent[];
@@ -23,6 +23,18 @@ export class Path {
 
   toJSON(): string {
     return this.path.reduce((pathString: string, component: PathComponent) => pathString + componentToString(component), '$');
+  }
+
+  get length(): number {
+    return this.path.length;
+  }
+
+  get(index: number) {
+    return this.path[index];
+  }
+
+  [Symbol.iterator]() {
+    return this.path[Symbol.iterator]();
   }
 
   static newRoot() {

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -2,8 +2,6 @@ export type PathComponent = number | string;
 
 const identifier = /^[a-zA-Z_]+[a-zA-Z0-9_]*$/;
 
-const ROOT_ID: string = '$';
-
 export class Path {
   private readonly path: PathComponent[];
 
@@ -20,15 +18,15 @@ export class Path {
   }
 
   connectTo(newRootPath: Path) {
-    return new Path(newRootPath.path.concat(this.path.slice(1)));
+    return new Path(newRootPath.path.concat(this.path));
   }
 
   toJSON(): string {
-    return this.path.slice(1).reduce((pathString: string, component: PathComponent) => pathString + componentToString(component), ROOT_ID);
+    return this.path.reduce((pathString: string, component: PathComponent) => pathString + componentToString(component), '$');
   }
 
   static newRoot() {
-    return new Path([ROOT_ID]);
+    return new Path([]);
   }
 
   static of(...path: PathComponent[]) {
@@ -38,10 +36,6 @@ export class Path {
   static ofNodes(path: PathComponent[]) {
     if (path.length === 0) {
       return ROOT;
-    }
-    if (path[0] !== ROOT_ID) {
-      const normalizedPath: Array<PathComponent> = [ROOT_ID];
-      return new Path(normalizedPath.concat(path));
     }
     return new Path(path);
   }

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -37,6 +37,47 @@ export class Path {
     return this.path[Symbol.iterator]();
   }
 
+  unset(object: any): any {
+    return this.set(object, undefined);
+  }
+
+  set(object: any, value: any): any {
+    if (this.path.length === 0) {
+      return value;
+    }
+    let index = -1;
+    const root = toObject(object, this.path);
+    let current = root;
+    for (index = 0; index < this.path.length - 1 && current; index++) {
+      const component = this.path[index];
+      const child = toObject(current[component], this.path);
+      current[component] = child;
+      current = child;
+    }
+    if (value === undefined) {
+      if (current !== undefined) {
+        delete current[this.path[index]];
+      }
+    } else {
+      current[this.path[index]] = value;
+    }
+    return root;
+
+    function toObject(current: any, path: PathComponent[]) {
+      if (typeof current === 'object') {
+        return current;
+      } else if (value !== undefined) {
+        if (typeof path[index + 1] === 'number') {
+          return [];
+        } else {
+          return {};
+        }
+      } else {
+        return undefined;
+      }
+    }
+  }
+
   static newRoot() {
     return new Path([]);
   }

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -30,10 +30,6 @@ export class Path {
   }
 
   static of(...path: PathComponent[]) {
-    return Path.ofNodes(path);
-  }
-
-  static ofNodes(path: PathComponent[]) {
     if (path.length === 0) {
       return ROOT;
     }

--- a/packages/core/src/testUtil.spec.ts
+++ b/packages/core/src/testUtil.spec.ts
@@ -26,4 +26,4 @@ export function verifyValid(result: ValidationResult, value: any, convertedValue
   return result;
 }
 
-test.skip('', () => {});
+test.skip('do not fail build because of no tests found', () => {});


### PR DESCRIPTION
* Simplify Path internal model: explicit $ root is not required
* Make Path components accessible via an iterator (Path being an Iterable), length and get(index)