### PR TITLE
Runtime Checks for Path Components & Refactor Path functions

### DIFF
--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -19,8 +19,12 @@ import {
   HasValueViolation,
 } from './validators';
 import { default as V } from './V';
-import { Path, property, index, ROOT } from './path';
+import { Path } from './path';
 import { expectUndefined, expectValid, expectViolations, verifyValid } from './testUtil.spec';
+
+const ROOT = Path.ROOT,
+  index = Path.index,
+  property = Path.property;
 
 async function expectGroupViolations(value: any, group: Group, validator: Validator, ...violations: Violation[]) {
   const result = await validator.validate(value, { group });

--- a/packages/core/src/path.spec.ts
+++ b/packages/core/src/path.spec.ts
@@ -1,9 +1,9 @@
-import { property, Path, index, ROOT, PathComponent } from './path';
+import { Path, PathComponent, ROOT, property, index } from './path';
 
 describe('path', () => {
   test('toJSON', () =>
     expect(
-      property('s p a c e s')
+      Path.property('s p a c e s')
         .index(5)
         .property('regular')
         .toJSON(),
@@ -11,18 +11,18 @@ describe('path', () => {
 
   test('Weird properties', () =>
     expect(
-      property('@foo')
+      Path.property('@foo')
         .property('a5')
         .property('http://xmlns.com/foaf/0.1/name')
         .toJSON(),
     ).toEqual('$["@foo"].a5["http://xmlns.com/foaf/0.1/name"]'));
 
   describe('of', () => {
-    test('equal to path constructed by builder', () => expect(Path.of(0, 'foo')).toEqual(index(0).property('foo')));
+    test('equal to path constructed by builder', () => expect(Path.of(0, 'foo')).toEqual(Path.index(0).property('foo')));
 
-    test('without root', () => expect(Path.of(0, 'foo')).toEqual(index(0).property('foo')));
+    test('without root', () => expect(Path.of(0, 'foo')).toEqual(Path.index(0).property('foo')));
 
-    test('alias for root', () => expect(Path.of()).toEqual(ROOT));
+    test('alias for root', () => expect(Path.of()).toEqual(Path.ROOT));
   });
 
   describe('iterable path', () => {
@@ -110,5 +110,15 @@ describe('path', () => {
         expect(() => Path.of(component)).toThrow();
       });
     });
+  });
+
+  describe('@deprecated', () => {
+    test('newRoot', () => expect(Path.newRoot()).toBe(Path.ROOT));
+
+    test('ROOT', () => expect(ROOT).toBe(Path.ROOT));
+
+    test('property', () => expect(property('test')).toEqual(Path.property('test')));
+
+    test('index', () => expect(index(0)).toEqual(Path.index(0)));
   });
 });

--- a/packages/core/src/path.spec.ts
+++ b/packages/core/src/path.spec.ts
@@ -67,4 +67,48 @@ describe('path', () => {
 
     test("delete doesn't create intermediate objects", () => expect(Path.of('nested', 'name').unset({})).toEqual({}));
   });
+
+  describe('validate components', () => {
+    test('string is not valid index', () => {
+      const component: any = 'foo';
+      expect(() => Path.of().index(component)).toThrow();
+    });
+
+    test('decimal is not valid index', () => {
+      const component: any = 1.2;
+      expect(() => Path.of().index(component)).toThrow();
+    });
+
+    test('negative value is not valid index', () => {
+      const component: any = -1;
+      expect(() => Path.of().index(component)).toThrow();
+    });
+
+    test('number is not valid property', () => {
+      const component: any = 0;
+      expect(() => Path.of().property(component)).toThrow();
+    });
+
+    test('array is not valid property', () => {
+      const component: any = [];
+      expect(() => Path.of().property(component)).toThrow();
+    });
+
+    describe('of', () => {
+      test('decimal is not a valid component', () => {
+        const component: any = 1.2;
+        expect(() => Path.of(component)).toThrow();
+      });
+
+      test('negative value is not a valid component', () => {
+        const component: any = -1;
+        expect(() => Path.of(component)).toThrow();
+      });
+
+      test('array is not a valid component', () => {
+        const component: any = [];
+        expect(() => Path.of(component)).toThrow();
+      });
+    });
+  });
 });

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -89,6 +89,14 @@ export class Path {
     return Path.ROOT;
   }
 
+  static property(property: string): Path {
+    return Path.ROOT.property(property);
+  }
+
+  static index(index: number): Path {
+    return Path.ROOT.index(index);
+  }
+
   static of(...path: PathComponent[]) {
     if (path.length === 0) {
       return Path.ROOT;
@@ -123,14 +131,23 @@ export class Path {
   }
 }
 
+/**
+ * @deprecated Use Path.ROOT instead
+ */
 export const ROOT = Path.ROOT;
 
+/**
+ * @deprecated Use Path.property instead
+ */
 export function property(property: string): Path {
-  return ROOT.property(property);
+  return Path.property(property);
 }
 
+/**
+ * @deprecated Use Path.index instead
+ */
 export function index(index: number): Path {
-  return ROOT.index(index);
+  return Path.index(index);
 }
 
 function componentToString(component: PathComponent) {

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -10,10 +10,12 @@ export class Path {
   }
 
   index(index: number): Path {
+    Path.validateIndex(index);
     return new Path(this.path.concat(index));
   }
 
   property(property: string): Path {
+    Path.validateProperty(property);
     return new Path(this.path.concat(property));
   }
 
@@ -86,7 +88,33 @@ export class Path {
     if (path.length === 0) {
       return ROOT;
     }
+    path.forEach(this.validateComponent);
     return new Path(path);
+  }
+
+  private static validateComponent(component: any) {
+    if (typeof component === 'number') {
+      if (component < 0 || !Number.isInteger(component)) {
+        throw new Error('Expected component to be an integer >= 0');
+      }
+    } else if (typeof component !== 'string') {
+      throw new Error(`Expected component to be a string or integer, got ${component}`);
+    }
+  }
+
+  private static validateIndex(index: any) {
+    if (typeof index !== 'number') {
+      throw new Error(`Expected index to be a number, got ${index}`);
+    }
+    if (index < 0 || !Number.isInteger(index)) {
+      throw new Error('Expected index to be an integer >= 0');
+    }
+  }
+
+  private static validateProperty(property: any) {
+    if (typeof property !== 'string') {
+      throw new Error(`Expected property to be a string, got ${property}`);
+    }
   }
 }
 

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -3,6 +3,8 @@ export type PathComponent = number | string;
 const identifier = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 export class Path {
+  public static readonly ROOT = new Path([]);
+
   private readonly path: PathComponent[];
 
   private constructor(path: PathComponent[]) {
@@ -80,13 +82,16 @@ export class Path {
     }
   }
 
+  /**
+   * @deprecated Use Path.ROOT instead
+   */
   static newRoot() {
-    return new Path([]);
+    return Path.ROOT;
   }
 
   static of(...path: PathComponent[]) {
     if (path.length === 0) {
-      return ROOT;
+      return Path.ROOT;
     }
     path.forEach(this.validateComponent);
     return new Path(path);
@@ -118,7 +123,7 @@ export class Path {
   }
 }
 
-export const ROOT = Path.newRoot();
+export const ROOT = Path.ROOT;
 
 export function property(property: string): Path {
   return ROOT.property(property);

--- a/packages/core/src/schema.spec.ts
+++ b/packages/core/src/schema.spec.ts
@@ -2,8 +2,10 @@ import { SchemaValidator, DiscriminatorViolation } from './schema';
 import { default as V } from './V';
 import { defaultViolations, TypeMismatch, ObjectValidator, HasValueViolation } from './validators';
 import { expectViolations, expectValid } from './testUtil.spec';
-import { property } from './path';
-import { ROOT } from './path';
+import { Path } from './path';
+
+const ROOT = Path.ROOT,
+  property = Path.property;
 
 describe('schema', () => {
   describe('Validator Schema', () => {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -1,5 +1,7 @@
 import deepEqual from 'deep-equal';
-import { Path, ROOT } from './path';
+import { Path } from './path';
+
+const ROOT = Path.ROOT;
 
 export interface ValidatorFn {
   (value: any, path: Path, ctx: ValidationContext): Promise<ValidationResult>;


### PR DESCRIPTION
* Runtime checks for Path components
* ROOT -> Path.ROOT
* property(string) -> Path.property(string)
* index(number) -> Path.index(number)
* Deprecate Path.newRoot, property and index methods