### PR TITLE
Rename Path.get(index) to componentAt and implement Path.get(object)

### DIFF
--- a/packages/core/src/path.spec.ts
+++ b/packages/core/src/path.spec.ts
@@ -38,16 +38,36 @@ describe('path', () => {
       expect(Array.from(Path.of(0, 'foo', 'bar'))).toEqual([0, 'foo', 'bar']);
     });
 
-    test('Path.get', () => {
+    test('componentAt', () => {
       const path = Path.of('foo', 0, 'bar');
-      expect(path.get(0)).toEqual('foo');
-      expect(path.get(1)).toEqual(0);
-      expect(path.get(2)).toEqual('bar');
+      expect(path.componentAt(0)).toEqual('foo');
+      expect(path.componentAt(1)).toEqual(0);
+      expect(path.componentAt(2)).toEqual('bar');
     });
 
-    test('Path.length', () => {
+    test('length', () => {
       expect(Path.of('foo', 0, 'bar').length).toEqual(3);
     });
+  });
+
+  describe('get', () => {
+    test('get root', () => expect(Path.ROOT.get('root')).toEqual('root'));
+
+    test('get property of root', () => expect(Path.of('name').get({ name: 'name' })).toEqual('name'));
+
+    test('get property of child', () => expect(Path.of('child', 'name').get({ child: { name: 'name' } })).toEqual('name'));
+
+    test('get index of root', () => expect(Path.of(1).get([1, 2])).toEqual(2));
+
+    test('get index of of child', () => expect(Path.of('child', 1).get({ child: [1, 2] })).toEqual(2));
+
+    test('get property of string', () => expect(Path.of('length').get('string')).toBeUndefined());
+
+    test('get property of nested string', () => expect(Path.of('child', 'name', 'length').get({ child: { name: 'string' } })).toBeUndefined());
+
+    test('get index of string', () => expect(Path.of(0).get('string')).toBeUndefined());
+
+    test('get index of nested string', () => expect(Path.of('child', 'name', 0).get({ child: { name: 'string' } })).toBeUndefined());
   });
 
   describe('set', () => {

--- a/packages/core/src/path.ts
+++ b/packages/core/src/path.ts
@@ -33,7 +33,7 @@ export class Path {
     return this.path.length;
   }
 
-  get(index: number) {
+  componentAt(index: number) {
     return this.path[index];
   }
 
@@ -41,17 +41,33 @@ export class Path {
     return this.path[Symbol.iterator]();
   }
 
-  unset(object: any): any {
-    return this.set(object, undefined);
+  get(root: any) {
+    if (this.path.length === 0) {
+      return root;
+    }
+    let current = root;
+    let index = 0;
+    for (; index < this.path.length - 1 && typeof current === 'object'; index++) {
+      const component = this.path[index];
+      current = current[component];
+    }
+    if (index === this.path.length - 1 && typeof current === 'object') {
+      return current[this.path[this.path.length - 1]];
+    }
+    return undefined;
   }
 
-  set(object: any, value: any): any {
+  unset(root: any): any {
+    return this.set(root, undefined);
+  }
+
+  set(root: any, value: any): any {
     if (this.path.length === 0) {
       return value;
     }
     let index = -1;
-    const root = toObject(object, this.path);
-    let current = root;
+    const _root = toObject(root, this.path);
+    let current = _root;
     for (index = 0; index < this.path.length - 1 && current; index++) {
       const component = this.path[index];
       const child = toObject(current[component], this.path);
@@ -65,7 +81,7 @@ export class Path {
     } else {
       current[this.path[index]] = value;
     }
-    return root;
+    return _root;
 
     function toObject(current: any, path: PathComponent[]) {
       if (typeof current === 'object') {


### PR DESCRIPTION
Having `set` and `unset` without `get` is just weird. Have to rename `get(index): PathComponent` to `componentAt`.