### PR TITLE
Object/Class Model Then

### DIFF
--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -612,12 +612,12 @@ describe('object then', () => {
       pw1: V.string(),
       pw2: V.string(),
     },
-    then: V.assertTrue(user => user.pw1 === user.pw2, 'PasswordsMatch'),
+    then: V.assertTrue(user => user.pw1 === user.pw2, 'PasswordVerification', Path.of('pw2')),
   });
 
   test('passwords match', () => expectValid({ pw1: 'test', pw2: 'test' }, passwordValidator));
 
-  test('passwords mismatch', () => expectViolations({ pw1: 'test', pw2: 't3st' }, passwordValidator, new Violation(Path.of(), 'PasswordsMatch')));
+  test('passwords mismatch', () => expectViolations({ pw1: 'test', pw2: 't3st' }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
 
   test('run after property validators', () => expectViolations({ pw1: 'test' }, passwordValidator, defaultViolations.notNull(Path.of('pw2'))));
 
@@ -627,12 +627,13 @@ describe('object then', () => {
       properties: {
         name: V.string(),
       },
-      then: V.assertTrue(user => user.pw1.indexOf(user.name) < 0, 'BadPassword', Path.of('name')),
+      then: V.assertTrue(user => user.pw1.indexOf(user.name) < 0, 'BadPassword', Path.of('pw1')),
     });
-    
-    test('BadPassword', () => expectViolations({ pw1: 'test', pw2: 'test', name: 'tes' }, userValidator, new Violation(Path.of('name'), 'BadPassword')));
-    
-    test('child then is applied after successfull parent then', () => expectViolations({ pw1: 'test', pw2: 't3st' }, passwordValidator, new Violation(Path.of(), 'PasswordsMatch')));
+
+    test('BadPassword', () => expectViolations({ pw1: 'test', pw2: 'test', name: 'tes' }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
+
+    test('child then is applied after successfull parent then', () =>
+      expectViolations({ pw1: 'test', pw2: 't3st', name: 'tes' }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
   });
 });
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -32,6 +32,7 @@ export interface ClassModel {
   readonly additionalProperties?: boolean | MapEntryModel | MapEntryModel[];
   readonly extends?: ClassParentModel;
   readonly ownProperties?: PropertyModel;
+  readonly then?: Validator;
 }
 
 export class ModelRef extends Validator {
@@ -163,6 +164,7 @@ export class SchemaValidator extends Validator {
         properties: classModel.properties,
         additionalProperties: classModel.additionalProperties,
         ownProperties,
+        then: classModel.then,
       };
       validator = new ObjectValidator(model);
     }


### PR DESCRIPTION
Having `V.object({}).then(crossPropertyValidator)` makes the object validator unextendable. This PR allows defining cross-property rules in object/class model thus allowing extension.