### PR TITLE
Local Instead of Own Properties/Then

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -134,7 +134,7 @@ const UserRegistrationValidator = V.object({
     password1: V.string().then(V.pattern(/[A-Z]/), V.pattern(/[a-z]/), V.pattern(/[0-9]/), V.size(8, 32)),
     password2: V.string(),
   },
-  // then: checkPassword, // An alternative way of defining cross-property rules. This allows extending UserRegistrationValidator.
+  // then: checkPassword, /* An alternative way of defining cross-property rules. This allows extending UserRegistrationValidator. */
 }).then(checkPassword); // Because of this, UserRegistrationValidator is actually a ThenValidator, which cannot be extended by V.object().
 
 // 3) INPUT VALIDATION
@@ -223,6 +223,9 @@ V.toInteger().then(V.min(1), V.max(1000), V.assertTrue(isPrime));
 3. references to parent model(s),
 4. local (non-inheritable) properties and
 5. then validator for cross-property rules
+6. local then for non-inheritable mapping
+
+### Named Properties
 
 An object may have any named property defined in a parent `properties`, it's own `properties` or `localProperties`, which in turn are not inherited.
 
@@ -270,6 +273,16 @@ const abike = { type: 'Bike', wheelCount: 2, sideBags: false };
 // ]
 ```
 
+### Optional Properties
+
+Most validation rules require a non-null and non-undefined value. Optional properties need to be defined with `V.optional`:
+
+```typescript
+V.optional(V.integer());
+```
+
+### Additional Properties
+
 Additional properties can be allowed or disallowed in general or by key pattern(s). Again a child model may further restrict parent's rules.
 
 ```typescript
@@ -302,13 +315,12 @@ All additional-property-validators consist of two parts, key and value validator
 returning success for the key. The value validator is only run if the key validator is successful. Setting `additionalProperties: true` is simply a shortcut for a case
 where both key and value validators allow anything; and `additionalProperties: false` is a shortcut for any key and a value validator that always returns `UnknownPropertyDenied` error.
 
-## Optional Properties
+### Then
 
-Most validation rules require a non-null and non-undefined value. Optional properties need to be defined with `V.optional`:
+An object may define inheritable cross-property rules with object model `then` and non-inheritable validations or, e.g. mappings to corresponding a classes, using `localThen`. As `localProperties`, `localThen` is not inherited by extending validators.
 
-```typescript
-V.optional(V.integer());
-```
+`Then` validation rules are run after all the properties are validated successfully and `localThen`
+is the last step in the validation chain. Inherited `then` rules are executed before child's own.
 
 ## <a name="array">Arrays</a>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -134,7 +134,8 @@ const UserRegistrationValidator = V.object({
     password1: V.string().then(V.pattern(/[A-Z]/), V.pattern(/[a-z]/), V.pattern(/[0-9]/), V.size(8, 32)),
     password2: V.string(),
   },
-}).then(checkPassword);
+  // then: checkPassword, // An alternative way of defining cross-property rules. This allows extending UserRegistrationValidator.
+}).then(checkPassword); // Because of this, UserRegistrationValidator is actually a ThenValidator, which cannot be extended by V.object().
 
 // 3) INPUT VALIDATION
 (await UserRegistrationValidator.validate({ password1: 'FooBar' })).getValue();
@@ -217,12 +218,15 @@ V.toInteger().then(V.min(1), V.max(1000), V.assertTrue(isPrime));
 
 `V.object` allows defining polymorphic object models. Object models consists of
 
-1. named properties that are references to other validators,
-2. additional property rules,
-3. references to parent models and
-4. own (non-inheritable) properties.
+1. named properties as references to other validators,
+2. rules defining what, if any, additional (unnamed) properties are allowed,
+3. references to parent model(s),
+4. local (non-inheritable) properties and
+5. then validator for cross-property rules
 
-An object may have any property defined in a parent model(s) properties or it's own properties. A child model may extend the validation rules of any parent property. In such a case parent's property validator is executed first and, if success, the converted value is validated against child's property validators. A child may only further restrict parent's property rules.
+An object may have any named property defined in a parent `properties`, it's own `properties` or `localProperties`, which in turn are not inherited.
+
+A child model may extend the validation rules of any inherited properties. In such a case inherited property validators are executed first and, if success, the converted value is validated against child's property validators. A child may only further restrict parent's property rules.
 
 ```typescript
 const vehicle = V.object({
@@ -230,7 +234,7 @@ const vehicle = V.object({
     wheelCount: V.required(V.toInteger(), V.min(0)),
     ownerName: V.optional(V.string()),
   },
-  ownProperties: {
+  localProperties: {
     type: 'Vehicle', // This rule is not inherited! A string or number value is a shortcur for V.hasValue(...).
   },
 });
@@ -241,7 +245,7 @@ const bike = V.object({
     wheelCount: V.allOf(V.min(1), V.max(3)), // Extend parent rules
     sideBags: V.boolean(), // Add a property
   },
-  ownProperties: {
+  localProperties: {
     type: 'Bike',
   },
 });
@@ -386,7 +390,7 @@ const schema = V.schema((schema: SchemaValidator) => ({
 (await schema.raw('Object').validate({ type: 'ObjectNormalizer', property: 'value' })).isSuccess();
 // false
 
-// Property based discriminator is validated as own property (i.e. not inherited)
+// Property based discriminator is validated as local property (i.e. not inherited)
 (await schema.raw('Object').validate({ type: 'Object' })).isSuccess();
 // true
 (await schema.raw('Object').validate({ type: 'ObjectNormalizer' })).isSuccess();

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -637,6 +637,46 @@ describe('object then', () => {
   });
 });
 
+describe('object localThen', () => {
+  const parent = V.object({
+    properties: {
+      name: V.string(),
+      upper: V.optional(V.boolean()),
+    },
+    then: V.map(obj => {
+      if (obj.upper) {
+        obj.name = (obj.name as string).toUpperCase();
+      }
+      return obj;
+    }),
+    localThen: V.map(obj => `parent:${obj.name}`),
+  });
+  const child = V.object({
+    extends: parent,
+    localThen: V.map(obj => `child:${obj.name}`),
+  });
+
+  test('parent', async done => {
+    expect((await parent.validate({ name: 'Darth' })).getValue()).toEqual('parent:Darth');
+    done();
+  });
+
+  test('child', async done => {
+    expect((await child.validate({ name: 'Luke' })).getValue()).toEqual('child:Luke');
+    done();
+  });
+
+  test('then applies for parent', async done => {
+    expect((await parent.validate({ name: 'Darth', upper: true })).getValue()).toEqual('parent:DARTH');
+    done();
+  });
+
+  test('then applies for child', async done => {
+    expect((await child.validate({ name: 'Luke', upper: true })).getValue()).toEqual('child:LUKE');
+    done();
+  });
+});
+
 describe('Date', () => {
   const now = new Date();
   const validator = V.object({

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -675,6 +675,17 @@ describe('object localThen', () => {
     expect((await child.validate({ name: 'Luke', upper: true })).getValue()).toEqual('child:LUKE');
     done();
   });
+
+  test('localThen is skipped on field validation error', async done => {
+    const model = V.object({
+      properties: {
+        name: V.string(),
+      },
+      localThen: V.map(obj => `parent:${obj.name}`),
+    });
+    await expectViolations({}, model, defaultViolations.notNull(property('name')));
+    done();
+  });
 });
 
 describe('Date', () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -447,18 +447,18 @@ describe('objects', () => {
     );
   });
 
-  describe('ownProperties', () => {
+  describe('localProperties', () => {
     const parent = V.object({
       properties: {
         type: V.string(),
       },
-      ownProperties: {
+      localProperties: {
         type: 'Parent',
       },
     });
     const child = V.object({
       extends: parent,
-      ownProperties: {
+      localProperties: {
         type: 'Child',
       },
     });

--- a/packages/core/src/schema.spec.ts
+++ b/packages/core/src/schema.spec.ts
@@ -237,6 +237,25 @@ describe('ClassModel.then', () => {
   });
 });
 
+describe('ClassModel.localThen', () => {
+  const schema = new SchemaValidator(schema => ({
+    discriminator: () => 'Model',
+    models: {
+      Model: {
+        properties: {
+          name: V.string(),
+        },
+        localThen: V.map(obj => `${obj.name}`),
+      },
+    },
+  }));
+
+  test('localThen is called', async done => {
+    expect((await schema.validate({ name: 'localThen' })).getValue()).toEqual('localThen');
+    done();
+  });
+});
+
 describe('Recursive object', () => {
   const schema = new SchemaValidator(schema => ({
     // TODO: Make discriminator optional if there's only one model

--- a/packages/core/src/schema.spec.ts
+++ b/packages/core/src/schema.spec.ts
@@ -191,7 +191,7 @@ describe('schema', () => {
       discriminator: 'type',
       models: {
         InvalidType: {
-          ownProperties: {
+          localProperties: {
             type: 'Foo', // As a schema this can never be valid
           },
         },

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -33,6 +33,7 @@ export interface ClassModel {
   readonly extends?: ClassParentModel;
   readonly localProperties?: PropertyModel;
   readonly then?: Validator;
+  readonly localThen?: Validator;
 }
 
 export class ModelRef extends Validator {
@@ -165,6 +166,7 @@ export class SchemaValidator extends Validator {
         additionalProperties: classModel.additionalProperties,
         localProperties,
         then: classModel.then,
+        localThen: classModel.localThen,
       };
       validator = new ObjectValidator(model);
     }

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -31,7 +31,7 @@ export interface ClassModel {
   readonly properties?: PropertyModel;
   readonly additionalProperties?: boolean | MapEntryModel | MapEntryModel[];
   readonly extends?: ClassParentModel;
-  readonly ownProperties?: PropertyModel;
+  readonly localProperties?: PropertyModel;
   readonly then?: Validator;
 }
 
@@ -152,18 +152,18 @@ export class SchemaValidator extends Validator {
       validator = models[name] as Validator;
     } else {
       const classModel = models[name] as ClassModel;
-      const ownProperties = classModel.ownProperties || {};
+      const localProperties = classModel.localProperties || {};
       if (isString(this.discriminator)) {
         const discriminatorProperty: string = this.discriminator as string;
-        if (!ownProperties[discriminatorProperty]) {
-          ownProperties[discriminatorProperty] = name;
+        if (!localProperties[discriminatorProperty]) {
+          localProperties[discriminatorProperty] = name;
         }
       }
       const model: Model = {
         extends: this.getParentValidators(classModel.extends, models, seen),
         properties: classModel.properties,
         additionalProperties: classModel.additionalProperties,
-        ownProperties,
+        localProperties,
         then: classModel.then,
       };
       validator = new ObjectValidator(model);

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -411,11 +411,11 @@ export class ObjectValidator extends Validator {
         thenValidator = maybeAllOfValidator(model.then);
       }
     }
-    this.localThenValidator = model.localThen;
     this.additionalProperties = additionalProperties.concat(getMapEntryValidators(model.additionalProperties));
     this.properties = mergeProperties(getPropertyValidators(model.properties), properties);
     this.localProperties = getPropertyValidators(model.localProperties);
     this.thenValidator = thenValidator;
+    this.localThenValidator = model.localThen;
   }
 
   withProperty(name: string, ...validator: Validator[]) {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -286,7 +286,7 @@ export type ParentModel = Model | ObjectValidator | (Model | ObjectValidator)[];
 export interface Model {
   readonly extends?: ParentModel;
   readonly properties?: PropertyModel;
-  readonly ownProperties?: PropertyModel;
+  readonly localProperties?: PropertyModel;
   readonly additionalProperties?: boolean | MapEntryModel | MapEntryModel[];
   readonly then?: Validator | Validator[];
 }
@@ -378,7 +378,7 @@ export function mergeProperties(from: Properties, to: Properties): Properties {
 export class ObjectValidator extends Validator {
   private readonly properties: Properties;
 
-  private readonly ownProperties: Properties;
+  private readonly localProperties: Properties;
 
   private readonly additionalProperties: MapEntryValidator[];
 
@@ -410,7 +410,7 @@ export class ObjectValidator extends Validator {
     }
     this.additionalProperties = additionalProperties.concat(getMapEntryValidators(model.additionalProperties));
     this.properties = mergeProperties(getPropertyValidators(model.properties), properties);
-    this.ownProperties = getPropertyValidators(model.ownProperties);
+    this.localProperties = getPropertyValidators(model.localProperties);
     this.thenValidator = thenValidator;
   }
 
@@ -445,11 +445,11 @@ export class ObjectValidator extends Validator {
     for (const key in this.properties) {
       promises.push(validateProperty(key, value[key], this.properties[key]));
     }
-    for (const key in this.ownProperties) {
-      promises.push(validateProperty(key, value[key], this.ownProperties[key]));
+    for (const key in this.localProperties) {
+      promises.push(validateProperty(key, value[key], this.localProperties[key]));
     }
     for (const key in value) {
-      if (!this.properties[key] && !this.ownProperties[key]) {
+      if (!this.properties[key] && !this.localProperties[key]) {
         promises.push(validateAdditionalProperty(key, value[key], this.additionalProperties));
       }
     }


### PR DESCRIPTION
BREAKING CHANGE: Improve naming by renaming object Model.ownProperties to localProperties.

Add object Model.localThen.

This PR will complete #32 .