### PR TITLE
Rename (object) Model to ObjectModel

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -216,7 +216,7 @@ V.toInteger().then(V.min(1), V.max(1000), V.assertTrue(isPrime));
 
 ## <a name="object">V.object</a>
 
-`V.object` allows defining polymorphic object models. Object models consists of
+`V.object` allows defining hierarchical object models (see [Schema](#schema) about polymorphism). `ObjectModel` consists of
 
 1. named properties as references to other validators,
 2. rules defining what, if any, additional (unnamed) properties are allowed,
@@ -317,7 +317,7 @@ where both key and value validators allow anything; and `additionalProperties: f
 
 ### Then
 
-An object may define inheritable cross-property rules with object model `then` and non-inheritable validations or, e.g. mappings to corresponding a classes, using `localThen`. As `localProperties`, `localThen` is not inherited by extending validators.
+An object may define inheritable cross-property rules with `ObjectModel.then` and non-inheritable validations or, e.g. mappings to corresponding a classes, using `localThen`. As `localProperties`, `localThen` is not inherited by extending validators.
 
 `Then` validation rules are run after all the properties are validated successfully and `localThen`
 is the last step in the validation chain. Inherited `then` rules are executed before child's own.
@@ -342,8 +342,7 @@ Polymorphims requires that objects are somehow tagged with a type used to valida
 one needs a _discriminator_ property or a function to infer object's type. This type is then used to actually validate the object.
 
 Polymorphic schemas are recursive in nature: 1) a child needs to know it's parents so that it may extend them and 2) unless the type information is natively bound to
-an object being validated, the parent needs to know it's children so that it may verify input's type and dispatch validation.
-As (direct) cyclic references are not possible, SchemaValidator is created with a callback function that supports referencing other models within the schema by name
+the object being validated, the parent needs to know it's children so that it may dispatch the validation to the correct child. As (direct) cyclic references are not possible, SchemaValidator is created with a callback function that supports referencing other models within the schema by name
 even before they are defined:
 
 1. An object may extend other models by simply referencing them by name.

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -13,7 +13,7 @@ import {
   isString,
   ValidationContext,
   ErrorViolation,
-  Model,
+  ObjectModel,
   IfValidator,
   WhenGroupValidator,
   HasValueViolation,
@@ -431,7 +431,7 @@ describe('objects', () => {
 
   test('custom property filtering extension', () => {
     class DropAllPropertiesValidator extends ObjectValidator {
-      constructor(model: Model) {
+      constructor(model: ObjectModel) {
         super(model);
       }
       validatePath(value: any, path: Path, ctx: ValidationContext): Promise<ValidationResult> {

--- a/packages/core/src/V.ts
+++ b/packages/core/src/V.ts
@@ -38,7 +38,7 @@ import {
   BooleanNormalizer,
   MinValidator,
   MaxValidator,
-  Model,
+  ObjectModel,
   ObjectValidator,
   ObjectNormalizer,
   MapValidator,
@@ -131,7 +131,7 @@ const V = {
 
   max: (max: number, inclusive = true) => new MaxValidator(max, inclusive),
 
-  object: (model: Model) => new ObjectValidator(model),
+  object: (model: ObjectModel) => new ObjectValidator(model),
 
   toObject: (property: string) => new ObjectNormalizer(property),
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -10,7 +10,7 @@ import {
   isString,
   Violation,
   TypeMismatch,
-  Model,
+  ObjectModel,
 } from './validators';
 import { Path } from '@finnair/path';
 
@@ -160,7 +160,7 @@ export class SchemaValidator extends Validator {
           localProperties[discriminatorProperty] = name;
         }
       }
-      const model: Model = {
+      const model: ObjectModel = {
         extends: this.getParentValidators(classModel.extends, models, seen),
         properties: classModel.properties,
         additionalProperties: classModel.additionalProperties,

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -281,9 +281,9 @@ export interface AssertTrue {
 
 export type PropertyModel = { [s: string]: string | number | Validator | Validator[] };
 
-export type ParentModel = Model | ObjectValidator | (Model | ObjectValidator)[];
+export type ParentModel = ObjectModel | ObjectValidator | (ObjectModel | ObjectValidator)[];
 
-export interface Model {
+export interface ObjectModel {
   readonly extends?: ParentModel;
   readonly properties?: PropertyModel;
   readonly localProperties?: PropertyModel;
@@ -320,7 +320,7 @@ function getParentValidators(parents: undefined | ParentModel): ObjectValidator[
     if (modelOrValidator instanceof ObjectValidator) {
       return modelOrValidator as ObjectValidator;
     }
-    return new ObjectValidator(modelOrValidator as Model);
+    return new ObjectValidator(modelOrValidator as ObjectModel);
   });
 }
 
@@ -389,7 +389,7 @@ export class ObjectValidator extends Validator {
 
   private readonly localThenValidator: undefined | Validator;
 
-  constructor(public readonly model: Model) {
+  constructor(public readonly model: ObjectModel) {
     super();
     let properties: Properties = {};
     let additionalProperties: MapEntryValidator[] = [];


### PR DESCRIPTION
BREAKING CHANGE: Rename (object) `Model` to `ObjectModel` for clarity #38 

Signed-off-by: Samppa Saarela <samppa.saarela@iki.fi>