### PR TITLE
Fix/arrow this

### DIFF
--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -465,12 +465,12 @@ export class ObjectValidator extends Validator {
       return ctx.failure(violations, convertedObject);
     });
     if (this.nextValidator) {
-      const next = this.nextValidator;
-      validationChain = validationChain.then(result => (result.isSuccess() ? next.validatePath(result.getValue(), path, ctx) : result));
+      const validator = this.nextValidator;
+      validationChain = validationChain.then(result => (result.isSuccess() ? validator.validatePath(result.getValue(), path, ctx) : result));
     }
     if (this.localNextValidator) {
-      const next = this.localNextValidator;
-      validationChain = validationChain.then(result => (result.isSuccess() ? next.validatePath(result.getValue(), path, ctx) : result));
+      const validator = this.localNextValidator;
+      validationChain = validationChain.then(result => (result.isSuccess() ? validator.validatePath(result.getValue(), path, ctx) : result));
     }
     return validationChain;
 

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -465,10 +465,12 @@ export class ObjectValidator extends Validator {
       return ctx.failure(violations, convertedObject);
     });
     if (this.nextValidator) {
-      validationChain = validationChain.then(result => (result.isSuccess() ? this.nextValidator!.validatePath(result.getValue(), path, ctx) : result));
+      const next = this.nextValidator;
+      validationChain = validationChain.then(result => (result.isSuccess() ? next.validatePath(result.getValue(), path, ctx) : result));
     }
     if (this.localNextValidator) {
-      validationChain = validationChain.then(result => (result.isSuccess() ? this.localNextValidator!.validatePath(result.getValue(), path, ctx) : result));
+      const next = this.localNextValidator;
+      validationChain = validationChain.then(result => (result.isSuccess() ? next.validatePath(result.getValue(), path, ctx) : result));
     }
     return validationChain;
 


### PR DESCRIPTION
Function calls to validatePath failed due to context (and thus also the functions) being lost in arrow functions. Extracted validators to constants in scope.