### PR TITLE
feat: setZone method for date-time types

### DIFF
--- a/packages/luxon/src/Vluxon.spec.ts
+++ b/packages/luxon/src/Vluxon.spec.ts
@@ -296,6 +296,13 @@ describe('Vluxon', () => {
       expect(new DateTimeUtcLuxon(dt).toJSON()).toEqual('2019-05-21T12:13:14Z');
     });
 
+    test('setZone', () => {
+      const local = LocalDateTimeLuxon.fromISO('2022-10-24T02:00:00');
+      const zoned = local.setZone(FixedOffsetZone.utcInstance);
+      expect(zoned).toBeInstanceOf(DateTimeLuxon);
+      expect(zoned.toJSON()).toEqual('2022-10-24T02:00:00Z');
+    });
+
     test('utcOffset of dateTime', () => {
       const dt = new LocalDateTimeLuxon(DateTime.fromISO('2019-05-21T12:13:14+03:00'));
       expect(dt.dateTime.offset).toEqual(0);
@@ -368,6 +375,13 @@ describe('Vluxon', () => {
       expect(dt.dateTime.offset).toEqual(180);
     });
 
+    test('setZone', () => {
+      const local = DateTimeLuxon.fromISO('2022-10-24T02:00:00+03');
+      const zoned = local.setZone(FixedOffsetZone.utcInstance);
+      expect(zoned).toBeInstanceOf(DateTimeLuxon);
+      expect(zoned.toJSON()).toEqual('2022-10-23T23:00:00Z');
+    });
+
     test('invalid DateTime throws', () => {
       expect(() => new DateTimeLuxon(DateTime.fromISO('2021-02-29T12:00:00'))).toThrow();
     });
@@ -427,6 +441,13 @@ describe('Vluxon', () => {
     test('convert dateTimeUtc to local time', () => {
       const dt = new DateTimeUtcLuxon(DateTime.fromISO('2019-05-21T12:13:14Z'));
       expect(new DateTimeLuxon(dt.dateTime.setZone(FixedOffsetZone.instance(3 * 60))).toJSON()).toEqual('2019-05-21T15:13:14+03:00');
+    });
+
+    test('setZone', () => {
+      const utc = DateTimeUtcLuxon.fromISO('2022-10-23T23:00:00Z');
+      const zoned = utc.setZone(FixedOffsetZone.instance(180));
+      expect(zoned).toBeInstanceOf(DateTimeLuxon);
+      expect(zoned.toJSON()).toEqual('2022-10-24T02:00:00+03:00');
     });
 
     test('utcOffset of dateTimeUtc', () => {
@@ -506,6 +527,13 @@ describe('Vluxon', () => {
       expect(dt.dateTime.offset).toEqual(180);
     });
 
+    test('setZone', () => {
+      const local = DateTimeMillisLuxon.fromISO('2022-10-24T02:00:00.123+03');
+      const zoned = local.setZone(FixedOffsetZone.utcInstance);
+      expect(zoned).toBeInstanceOf(DateTimeMillisLuxon);
+      expect(zoned.toJSON()).toEqual('2022-10-23T23:00:00.123Z');
+    });
+
     test('invalid leap date throws', () => {
       expect(() => new DateTimeMillisLuxon(DateTime.fromISO('2021-02-29T12:00:00.000Z'))).toThrow();
     });
@@ -572,6 +600,13 @@ describe('Vluxon', () => {
     test('utcOffset of dateTimeMillisUtc', () => {
       const dt = new DateTimeMillisUtcLuxon(DateTime.fromISO('2019-05-21T12:13:14.123+03:00'));
       expect(dt.dateTime.offset).toEqual(0);
+    });
+
+    test('setZone', () => {
+      const utc = DateTimeMillisUtcLuxon.fromISO('2022-10-23T23:00:00.123Z');
+      const zoned = utc.setZone(FixedOffsetZone.instance(180));
+      expect(zoned).toBeInstanceOf(DateTimeMillisLuxon);
+      expect(zoned.toJSON()).toEqual('2022-10-24T02:00:00.123+03:00');
     });
 
     test('invalid leap date throws', () => {

--- a/packages/luxon/src/luxon.ts
+++ b/packages/luxon/src/luxon.ts
@@ -189,6 +189,10 @@ export class LocalDateTimeLuxon extends LuxonDateTime {
     super(input);
   }
 
+  setZone(zone: Zone): DateTimeLuxon {
+    return new DateTimeLuxon(this.dateTime.setZone(zone, { keepLocalTime: true }));
+  }
+
   public static nowLocal(options?: DateTimeJSOptions) {
     return new LocalDateTimeLuxon(DateTime.local(options));
   }
@@ -255,6 +259,10 @@ export class DateTimeLuxon extends LuxonDateTime {
     super(input);
   }
 
+  setZone(zone: Zone): DateTimeLuxon {
+    return new DateTimeLuxon(this.dateTime.setZone(zone, { keepLocalTime: false }));
+  }
+
   public static now(options?: DateTimeJSOptions) {
     return new DateTimeLuxon(DateTime.local(options));
   }
@@ -304,6 +312,10 @@ export class DateTimeLuxon extends LuxonDateTime {
 export class DateTimeUtcLuxon extends LuxonDateTime {
   constructor(input: LuxonDateTimeInput) {
     super(input);
+  }
+
+  setZone(zone: Zone): DateTimeLuxon {
+    return new DateTimeLuxon(this.dateTime.setZone(zone, { keepLocalTime: false }));
   }
 
   public static now() {
@@ -368,6 +380,10 @@ export class DateTimeMillisLuxon extends LuxonDateTime {
     super(input);
   }
 
+  setZone(zone: Zone): DateTimeMillisLuxon {
+    return new DateTimeMillisLuxon(this.dateTime.setZone(zone, { keepLocalTime: false }));
+  }
+
   public static now(options?: DateTimeJSOptions) {
     return new DateTimeMillisLuxon(DateTime.local(options));
   }
@@ -417,6 +433,10 @@ export class DateTimeMillisLuxon extends LuxonDateTime {
 export class DateTimeMillisUtcLuxon extends LuxonDateTime {
   constructor(input: LuxonDateTimeInput) {
     super(input);
+  }
+
+  setZone(zone: Zone): DateTimeMillisLuxon {
+    return new DateTimeMillisLuxon(this.dateTime.setZone(zone, { keepLocalTime: false }));
   }
 
   public static now() {


### PR DESCRIPTION
setZone provides a natural zone-aware conversion from one type to another:
* LocalDateTimeLuxon.setZone(zone) => DateTimeLuxon (keeps local time!)
* DateTimeLuxon.setZone(zone) => DateTimeLuxon
* DateTimeUtcLuxon.setZone(zone) => DateTimeLuxon
* DateTimeMillisLuxon.setZone(zone) => DateTimeMillisLuxon
* DateTimeMillisUtcLuxon.setZone(zone) => DateTimeMillisLuxon
