### PR TITLE
feat!: Truncate trailing undefined elements from an array when using Path.set

### DIFF
--- a/packages/path/README.md
+++ b/packages/path/README.md
@@ -64,6 +64,9 @@ changes.forEach((newValue, path) => {
 updateResource(latestValue);
 ```
 
+NOTE: Updating an array with `Path.set` will truncate possible undefined values from the end of the array. This allows
+removing trailing elements without leaving undefined elements in place.
+
 ### Include/Exclude Projection
 
 While GraphQL is all about projections, something similar can also be implemented in a REST API with include/exclude parameters. `Projection` and `parsePathMatcher` function provides means to process results safely based on such a user input. This is, of course, very simplified projection compared to what GraphQL has to offer, but it's also... well, simpler.
@@ -92,9 +95,7 @@ Path.of(); // Root object $ - also Path.ROOT
 Path.of('array', 1, 'property'); // $.array[1].property
 
 // Constructing with fluent syntax
-Path.of()
-  .property('array')
-  .index(0); // $.array[0]
+Path.of().property('array').index(0); // $.array[0]
 
 // Concatenating Paths
 Path.of('parent').concat(Path.of('child', 'name')); // $.parent.child.name
@@ -118,6 +119,9 @@ Path.of('parent', 'child', 'name').set({}, 'child name'); // { parent: { child: 
 Path.of('array', 1).unset({ array: [1, 2, 3] }); // { array: [1, undefined, 3] }
 // ...but unsetting a value doesn't create intermediate objects
 Path.of('array', 1).unset({}); // {}
+
+// Trailing undefined elements will be removed from an array (i.e. array is resized)
+Path.of('array', 2).set({ array: [1, undefined, 3] }, undefined); // { array: [1] } where array.length === 1
 
 // toJSON() returns JsonPath compatible serialization
 Path.of('array', 0, 'property with spaces').toJSON(); // $.array[0]["property with spaces"]

--- a/packages/path/src/Path.spec.ts
+++ b/packages/path/src/Path.spec.ts
@@ -3,21 +3,10 @@ import { PathMatcher } from './PathMatcher';
 import { AnyProperty, AnyIndex } from './matchers';
 
 describe('path', () => {
-  test('toJSON', () =>
-    expect(
-      Path.property('s p a c e s')
-        .index(5)
-        .property('regular')
-        .toJSON(),
-    ).toEqual('$["s p a c e s"][5].regular'));
+  test('toJSON', () => expect(Path.property('s p a c e s').index(5).property('regular').toJSON()).toEqual('$["s p a c e s"][5].regular'));
 
   test('Weird properties', () =>
-    expect(
-      Path.property('@foo')
-        .property('a5')
-        .property('http://xmlns.com/foaf/0.1/name')
-        .toJSON(),
-    ).toEqual('$["@foo"].a5["http://xmlns.com/foaf/0.1/name"]'));
+    expect(Path.property('@foo').property('a5').property('http://xmlns.com/foaf/0.1/name').toJSON()).toEqual('$["@foo"].a5["http://xmlns.com/foaf/0.1/name"]'));
 
   describe('of', () => {
     test('equal to path constructed by builder', () => expect(Path.of(0, 'foo')).toEqual(Path.index(0).property('foo')));
@@ -82,6 +71,14 @@ describe('path', () => {
 
     test('creates root object if necessary', () =>
       expect(Path.of(0, 'array', 1, 'name').set(undefined, 'name')).toEqual([{ array: [undefined, { name: 'name' }] }]));
+
+    test('truncates undefined tail from an array', () => {
+      const obj = { array: [1, undefined, 3] };
+      expect(Path.of('array', 2).set(obj, undefined));
+      expect(obj).toEqual({ array: [1] });
+      expect(obj.array.length).toBe(1);
+      expect(obj.array[2]).toBeUndefined();
+    });
   });
 
   describe('unset', () => {

--- a/packages/path/src/Path.ts
+++ b/packages/path/src/Path.ts
@@ -71,21 +71,29 @@ export class Path {
     if (this.path.length === 0) {
       return value;
     }
-    let index = -1;
+    let pathIndex = -1;
     const _root = toObject(root, this.path);
     let current = _root;
-    for (index = 0; index < this.path.length - 1 && current; index++) {
-      const component = this.path[index];
+    for (pathIndex = 0; pathIndex < this.path.length - 1 && current; pathIndex++) {
+      const component = this.path[pathIndex];
       const child = toObject(current[component], this.path);
       current[component] = child;
       current = child;
     }
     if (value === undefined) {
       if (current !== undefined) {
-        delete current[this.path[index]];
+        delete current[this.path[pathIndex]];
+        // Truncate undefined tail of an array
+        if (Array.isArray(current)) {
+          let i = current.length - 1;
+          while (i >= 0 && current[i] === undefined) {
+            i--;
+          }
+          current.length = i + 1;
+        }
       }
     } else {
-      current[this.path[index]] = value;
+      current[this.path[pathIndex]] = value;
     }
     return _root;
 
@@ -93,7 +101,7 @@ export class Path {
       if (typeof current === 'object') {
         return current;
       } else if (value !== undefined) {
-        if (typeof path[index + 1] === 'number') {
+        if (typeof path[pathIndex + 1] === 'number') {
           return [];
         } else {
           return {};


### PR DESCRIPTION
Before: Calling `Path.of(0).set([1], undefined)` would result in `[undefined]`.
Now: Calling `Path.of(0).set([1], undefined)` will result in `[]`.
