### PR TITLE
feat: providing a new validator V.notEmptyObject()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+/.idea/

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -168,7 +168,7 @@ const UserRegistrationValidator = V.object({
 
 ## Vhy?
 
-- Machine readable error reports
+- Machine-readable error reports
   - V's Violation is easily readable to any developer and can be used to localize and target human readable error messages in the UI
   - Errors serialize to JSON nicely for easy interoperability
 - Asynchronous processing allows I/O based validators
@@ -332,7 +332,7 @@ Arrays are defined in terms of their element type:
 V.array(V.integer()).next(V.size(1, 100)); // An integer array of size 1 to 100
 ```
 
-Note that basic validators do not handle polymoprhism even though they support inheritance. For example this definition would not validate elements against `bike` or `aircraft`:
+Note that basic validators do not handle polymorphism even though they support inheritance. For example this definition would not validate elements against `bike` or `aircraft`:
 
 ```typescript
 V.array(vehicle);
@@ -340,11 +340,11 @@ V.array(vehicle);
 
 ## <a name="schema">Schema</a>
 
-Polymorphims requires that objects are somehow tagged with a type used to validate it. Since plain JSON/JavaScript objects do not have type information attached to them
+Polymorphism requires that objects are somehow tagged with a type used to validate it. Since plain JSON/JavaScript objects do not have type information attached to them
 one needs a _discriminator_ property or a function to infer object's type. This type is then used to actually validate the object.
 
-Polymorphic schemas are recursive in nature: 1) a child needs to know it's parents so that it may extend them and 2) unless the type information is natively bound to
-the object being validated, the parent needs to know it's children so that it may dispatch the validation to the correct child. As (direct) cyclic references are not possible, SchemaValidator is created with a callback function that supports referencing other models within the schema by name
+Polymorphic schemas are recursive in nature: 1) a child needs to know its parents so that it may extend them and 2) unless the type information is natively bound to
+the object being validated, the parent needs to know its children so that it may dispatch the validation to the correct child. As (direct) cyclic references are not possible, SchemaValidator is created with a callback function that supports referencing other models within the schema by name
 even before they are defined:
 
 1. An object may extend other models by simply referencing them by name.
@@ -525,61 +525,62 @@ class MyViolation extends Violation {
 
 Unless otherwise stated, all validators require non-null and non-undefined values.
 
-| V.                      | Arguments                                                        | Description                                                                                                                                |
-| ----------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| fn                      |  fn: ValidatorFn, type?: string                                  | Function reference as a validator. A short cut for extending Validator class.                                                              |
-| ignore                  |                                                                  | Converts any input value to undefined.                                                                                                     |
-| any                     |                                                                  | Accepts any value, including undefined and null.                                                                                           |
-| check                   | ...allOf: Validator[]                                            | Runs all the validators and, if successful, returns the original value discarding any conversions.                                         |
-| map                     | fn: MappingFn, error?: any                                       | Mapping function to convert a value. Catches and converts errors to Violations                                                             |
-| optional                | type: Validator, ...allOf: Validator[]                           | Allows null and undefined. For other values, runs first the `type` validator and then `allOf` the rest validators.                         |
-| required                | type: Validator, ...allOf: Validator[]                           | 1) Requires a non-null and non-undefined value, 2) runs `type` validator and 3) then `allOf` the rest validators.                          |
-| string                  |                                                                  | Requires string or String.                                                                                                                 |
-| toString                |                                                                  | Converts primitive values to (primitive) strings.                                                                                          |
-| notNull                 |                                                                  | Requires non-null and non-undefined value.                                                                                                 |
-| nullOrUndefined         |                                                                  | Requires null or undefined value.                                                                                                          |
-| notEmpty                |                                                                  | Requires non-null, non-undefined and not empty. Works with anything having numeric `length` property, e.g. string or array.                |
-| notBlank                |                                                                  | Requires non-null, non-undefined and not blank (whitespace only string) values.                                                            |
-| uuid                    | version?: number                                                 | Uses `uuid-validate` package to validate input.                                                                                            |
-| pattern                 |  pattern: string \| RegExp, flags?: string                       | Tests input against the pattern.                                                                                                           |
-| toPattern               |                                                                  | Combines `toString` normalization with pattern validator.                                                                                  |
-| boolean                 |                                                                  | Requires that input is primitive boolean.                                                                                                  |
-| toBoolean               | truePattern?: RegExp, falsePattern?: RegExp                      | Converts strings and numbers to boolean. Patterns for true and false can be configured using regexp, defaults to true and false.           |
-| number                  |                                                                  | Requires that input is either primitive number or Number and not NaN.                                                                      |
-| toNumber                |                                                                  | Converts numeric strings to numbers.                                                                                                       |
-| integer                 |                                                                  |  Requires that input is integer.                                                                                                           |
-| toInteger               |                                                                  | Converts numeric strings to integers.                                                                                                      |
-| min                     | min: number, inclusive = true                                    | Asserts that numeric input is greater than or equal (if inclusive = true) than `min`.                                                      |
-| max                     | max: number, inclusive = true                                    | Asserts that numeric input is less than or equal (if inclusive = true) than `max`.                                                         |
-| date                    |                                                                  | Reqruires a valid date. Converts string to Date.                                                                                           |
-| enum                    | enumType: object, name: string                                   | Requires that the input is one of given enumType. Name of the enum provided for error message.                                             |
-| assertTrue              | fn: AssertTrue, type: string = 'AssertTrue', path?: Path         | Requires that the input passes `fn`. Type can be provided for error messages and path to target a sub property                             |
-| hasValue                | expectedValue: any                                               | Requires that the input matches `expectedValue`. Uses `node-deep-equal` library.                                                           |
-| object                  | model: Model                                                     | Defines an [Object validator](#object) based on provided Model.                                                                            |
-| toObject                | property: string                                                 | Converts a primitive value to object `{ property: 'value' }`. Undefined is passed on as such.                                              |
-| schema                  | callback: (schema: SchemaValidator) => SchemaModel               | Defines a [SchemaValidator](#schema) for a discriminator and models.                                                                       |
-| properties              | keys: Validator \| Validator[], values: Validator \| Validator[] | A shortcut for object with `additionalProperties`.                                                                                         |
-| mapType                 | keys: Validator, values: Validator, jsonSafeMap: boolean = true  | [Map validator](#map)                                                                                                                      |
-| toMapType(keys, values) | keys: Validator, values: Validator                               | Converts an array-of-arrays representation of a Map into a JsonSafeMap instance.                                                           |
-| array                   | ...items: Validator[]                                            | [Array validator](#array)                                                                                                                  |
-| toArray                 | items: Validator                                                 | Converts undefined to an empty array and non-arrays to single-valued arrays.                                                               |
-| size                    | min: number, max: number                                         |  Asserts that input's numeric `length` property is between min and max (both inclusive).                                                   |
-| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. Validators are run in parallel and in case they convert the input, all must provide same output. |
-| anyOf                   | ...validators: Validator[]                                       | Requires minimum one of given validators matches. Validators are run in parallel and in case of failure, all violations will be returned.  |
-| oneOf                   | ...validators: Validator[]                                       | Requires that exactly one of the given validators match.                                                                                   |
-| compositionOf           | ...validators: Validator[]                                       | Runs given the validators one after another, chaining the result.                                                                          |
-| emptyToUndefined        |                                                                  | Converts null or empty string to undefined. Does not touch any other values.                                                               |
-| emptyToNull             |                                                                  | Converts undefined or empty string to null. Does not touch any other values.                                                               |
-| emptyTo                 | defaultValue: string                                             | Uses given `defaultValue` in place of null, undefined or empty string. Does not touch any other values.                                    |
-| nullTo                  | defaultValue: string                                             | Uses given `defaultValue` in place of null. Does not touch any other values.                                                               |
-| undefinedToNull         |                                                                  | Convets undefined to null. Does not touch any other values.                                                                                |
-| if...elseif...else      | fn: AssertTrue, ...allOf: Validator[]                            | Configures validators (`allOf`) to be executed for cases where if/elseif AssertTrue fn returns true.                                       |
-| whenGroup...otherwise   | group: GroupOrName, ...allOf: Validator[]                        | Defines validation rules (`allOf`) to be executed for given `ValidatorOptions.group`.                                                      |
-| json                    | ...validators: Validator[]                                       | Parse JSON input and validate it against given validators.                                                                                 |
+| V.                       | Arguments                                                         | Description                                                                                                                                |
+|--------------------------|-------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| fn                       | fn: ValidatorFn, type?: string                                    | Function reference as a validator. A short cut for extending Validator class.                                                              |
+| ignore                   |                                                                   | Converts any input value to undefined.                                                                                                     |
+| any                      |                                                                   | Accepts any value, including undefined and null.                                                                                           |
+| check                    | ...allOf: Validator[]                                             | Runs all the validators and, if successful, returns the original value discarding any conversions.                                         |
+| map                      | fn: MappingFn, error?: any                                        | Mapping function to convert a value. Catches and converts errors to Violations                                                             |
+| optional                 | type: Validator, ...allOf: Validator[]                            | Allows null and undefined. For other values, runs first the `type` validator and then `allOf` the rest validators.                         |
+| required                 | type: Validator, ...allOf: Validator[]                            | 1) Requires a non-null and non-undefined value, 2) runs `type` validator and 3) then `allOf` the rest validators.                          |
+| string                   |                                                                   | Requires string or String.                                                                                                                 |
+| toString                 |                                                                   | Converts primitive values to (primitive) strings.                                                                                          |
+| notNull                  |                                                                   | Requires non-null and non-undefined value.                                                                                                 |
+| nullOrUndefined          |                                                                   | Requires null or undefined value.                                                                                                          |
+| notEmptyObject           | optionalProperties?: string[]                                     | Asserts that an object validated is not empty. When `optionalProperties` are provided, outputs them in the Violation output.               |
+| notEmpty                 |                                                                   | Requires non-null, non-undefined and not empty. Works with anything having numeric `length` property, e.g. string or array.                |
+| notBlank                 |                                                                   | Requires non-null, non-undefined and not blank (whitespace only string) values.                                                            |
+| uuid                     | version?: number                                                  | Uses `uuid-validate` package to validate input.                                                                                            |
+| pattern                  | pattern: string \| RegExp, flags?: string                         | Tests input against the pattern.                                                                                                           |
+| toPattern                |                                                                   | Combines `toString` normalization with pattern validator.                                                                                  |
+| boolean                  |                                                                   | Requires that input is primitive boolean.                                                                                                  |
+| toBoolean                | truePattern?: RegExp, falsePattern?: RegExp                       | Converts strings and numbers to boolean. Patterns for true and false can be configured using regexp, defaults to true and false.           |
+| number                   |                                                                   | Requires that input is either primitive number or Number and not NaN.                                                                      |
+| toNumber                 |                                                                   | Converts numeric strings to numbers.                                                                                                       |
+| integer                  |                                                                   | Requires that input is integer.                                                                                                            |
+| toInteger                |                                                                   | Converts numeric strings to integers.                                                                                                      |
+| min                      | min: number, inclusive = true                                     | Asserts that numeric input is greater than or equal (if inclusive = true) than `min`.                                                      |
+| max                      | max: number, inclusive = true                                     | Asserts that numeric input is less than or equal (if inclusive = true) than `max`.                                                         |
+| date                     |                                                                   | Requires a valid date. Converts string to Date.                                                                                            |
+| enum                     | enumType: object, name: string                                    | Requires that the input is one of given enumType. Name of the enum provided for error message.                                             |
+| assertTrue               | fn: AssertTrue, type: string = 'AssertTrue', path?: Path          | Requires that the input passes `fn`. Type can be provided for error messages and path to target a sub property                             |
+| hasValue                 | expectedValue: any                                                | Requires that the input matches `expectedValue`. Uses `node-deep-equal` library.                                                           |
+| object                   | model: Model                                                      | Defines an [Object validator](#object) based on provided Model.                                                                            |
+| toObject                 | property: string                                                  | Converts a primitive value to object `{ property: 'value' }`. Undefined is passed on as such.                                              |
+| schema                   | callback: (schema: SchemaValidator) => SchemaModel                | Defines a [SchemaValidator](#schema) for a discriminator and models.                                                                       |
+| properties               | keys: Validator \| Validator[], values: Validator \| Validator[]  | A shortcut for object with `additionalProperties`.                                                                                         |
+| mapType                  | keys: Validator, values: Validator, jsonSafeMap: boolean = true   | [Map validator](#map)                                                                                                                      |
+| toMapType(keys, values)  | keys: Validator, values: Validator                                | Converts an array-of-arrays representation of a Map into a JsonSafeMap instance.                                                           |
+| array                    | ...items: Validator[]                                             | [Array validator](#array)                                                                                                                  |
+| toArray                  | items: Validator                                                  | Converts undefined to an empty array and non-arrays to single-valued arrays.                                                               |
+| size                     | min: number, max: number                                          | Asserts that input's numeric `length` property is between min and max (both inclusive).                                                    |
+| allOf                    | ...validators: Validator[]                                        | Requires that all given validators match. Validators are run in parallel and in case they convert the input, all must provide same output. |
+| anyOf                    | ...validators: Validator[]                                        | Requires minimum one of given validators matches. Validators are run in parallel and in case of failure, all violations will be returned.  |
+| oneOf                    | ...validators: Validator[]                                        | Requires that exactly one of the given validators match.                                                                                   |
+| compositionOf            | ...validators: Validator[]                                        | Runs given the validators one after another, chaining the result.                                                                          |
+| emptyToUndefined         |                                                                   | Converts null or empty string to undefined. Does not touch any other values.                                                               |
+| emptyToNull              |                                                                   | Converts undefined or empty string to null. Does not touch any other values.                                                               |
+| emptyTo                  | defaultValue: string                                              | Uses given `defaultValue` in place of null, undefined or empty string. Does not touch any other values.                                    |
+| nullTo                   | defaultValue: string                                              | Uses given `defaultValue` in place of null. Does not touch any other values.                                                               |
+| undefinedToNull          |                                                                   | Converts undefined to null. Does not touch any other values.                                                                               |
+| if...elseif...else       | fn: AssertTrue, ...allOf: Validator[]                             | Configures validators (`allOf`) to be executed for cases where if/elseif AssertTrue fn returns true.                                       |
+| whenGroup...otherwise    | group: GroupOrName, ...allOf: Validator[]                         | Defines validation rules (`allOf`) to be executed for given `ValidatorOptions.group`.                                                      |
+| json                     | ...validators: Validator[]                                        | Parse JSON input and validate it against given validators.                                                                                 |
 
 ## Violations
 
-All `Violations` have following propertie in common:
+All `Violations` have the following properties in common:
 
 | Property           | Description                                                                                                                                                                                          |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -591,23 +592,24 @@ All `Violations` have following propertie in common:
 
 ### Built-in Violations
 
-| Class                  | Type                  | Properties                       | Description                                                                         |
-| ---------------------- | --------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
-| TypeMismatch           | TypeMismatch          | expected: string                 | Type mismatch: `expected` is a description of expected type.                        |
-| EnumMismatch           | EnumMismatch          | enumType: string                 | Invalid enum value: `enumType` is the name of the expected enumeration.             |
-| ErrorViolation         | Error                 | error: any                       | An unspecified Error that was thrown and caught.                                    |
-| HasValueViolation      | HasValue              | expectedValue: any               | Input does not match (deepEqual) expectedValue.                                     |
-| PatternViolationi      | Pattern               | pattern: string                  | Input does not match the regular expression (pattern).                              |
-| OneOfMismatch          | OneOf                 | matches: number                  | Input matches 0 or >= 2 of the configured validators.                               |
-| MaxViolation           | Max                   | max: number, inclusive: boolean  | Input is greater-than or greater-than-or-equal, if `inclusive=true`, than `max`.    |
-| MinViolation           | Min                   |  min: number, inclusive: boolean | Input is less-than or less-than-or-equal if inclusive=true than `min`.              |
-| SizeViolation          | Size                  | min: number, max: number         | Input `length` (required numeric property) is less-than `min` or grater-than `max`. |
-| Violation              | NotNull               |                                  | Input is `null` or `undefined`.                                                     |
-| Violation              | NotEmpty              |                                  | Input is `null`, `undefined` or empty (i.e. input.length === 0).                    |
-| Violation              | NotBlank              |                                  | Input (string) is `null`, `undefined` or empty when trimmed.                        |
-| Violation              | UnknownProperty       |                                  | Additional property that is denied by default (see ignoreUnknownProperties).        |
-| Violation              | UnknownPropertyDenied |                                  | Explicitly denied additional property.                                              |
-| DiscriminatorViolation | Discriminator         | expectedOneOf: string[]          | Invalid discriminator value: `expectedOneOf` is a list of known types.              |
+| Class                   | Type                  | Properties                       | Description                                                                              |
+|-------------------------|-----------------------|----------------------------------|------------------------------------------------------------------------------------------|
+| TypeMismatch            | TypeMismatch          | expected: string                 | Type mismatch: `expected` is a description of expected type.                             |
+| EnumMismatch            | EnumMismatch          | enumType: string                 | Invalid enum value: `enumType` is the name of the expected enumeration.                  |
+| ErrorViolation          | Error                 | error: any                       | An unspecified Error that was thrown and caught.                                         |
+| HasValueViolation       | HasValue              | expectedValue: any               | Input does not match (deepEqual) expectedValue.                                          |
+| PatternViolationi       | Pattern               | pattern: string                  | Input does not match the regular expression (pattern).                                   |
+| OneOfMismatch           | OneOf                 | matches: number                  | Input matches 0 or >= 2 of the configured validators.                                    |
+| MaxViolation            | Max                   | max: number, inclusive: boolean  | Input is greater-than or greater-than-or-equal, if `inclusive=true`, than `max`.         |
+| MinViolation            | Min                   |  min: number, inclusive: boolean | Input is less-than or less-than-or-equal if inclusive=true than `min`.                   |
+| SizeViolation           | Size                  | min: number, max: number         | Input `length` (required numeric property) is less-than `min` or grater-than `max`.      |
+| Violation               | NotNull               |                                  | Input is `null` or `undefined`.                                                          |
+| Violation               | NotEmpty              |                                  | Input is `null`, `undefined` or empty (i.e. input.length === 0).                         |
+| NotEmptyObjectViolation | NotEmptyObject        | optionalProperties: string[]     | Input is an empty object, if `optionalProperties` provided Validation output shows them. |
+| Violation               | NotBlank              |                                  | Input (string) is `null`, `undefined` or empty when trimmed.                             |
+| Violation               | UnknownProperty       |                                  | Additional property that is denied by default (see ignoreUnknownProperties).             |
+| Violation               | UnknownPropertyDenied |                                  | Explicitly denied additional property.                                                   |
+| DiscriminatorViolation  | Discriminator         | expectedOneOf: string[]          | Invalid discriminator value: `expectedOneOf` is a list of known types.                   |
 
 ## Roadmap
 

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect } from 'vitest';
 import {
   Validator,
   Violation,
@@ -359,7 +359,7 @@ describe('objects', () => {
 
     test('parent conversion is available for child validator', () => expectValid({ foo: '1' }, validator, { foo: 1 }));
 
-    test("invalid value for parent doesn't run child validator", () =>
+    test('invalid value for parent doesn\'t run child validator', () =>
       expectViolations({ foo: 'a' }, validator, defaultViolations.number('a', NumberFormat.integer, property('foo'))));
 
     test('invalid value for child validator', () => expectViolations({ foo: 0 }, validator, defaultViolations.min(1, true, 0, property('foo'))));
@@ -384,6 +384,7 @@ describe('objects', () => {
       password1: string;
       password2: string;
     }
+
     class PasswordRequest implements IPasswordRequest {
       password1: string;
 
@@ -407,10 +408,16 @@ describe('objects', () => {
     );
 
     test('matching passwords', async () =>
-      await expectValid({ password1: 'pwd', password2: 'pwd' }, validator, new PasswordRequest({ password1: 'pwd', password2: 'pwd' })));
+      await expectValid({ password1: 'pwd', password2: 'pwd' }, validator, new PasswordRequest({
+        password1: 'pwd',
+        password2: 'pwd',
+      })));
 
     test('non-matching passwords', async () =>
-      await expectViolations({ password1: 'pwd', password2: 'pwb' }, validator, new Violation(property('password1'), 'ConfirmPassword')));
+      await expectViolations({
+        password1: 'pwd',
+        password2: 'pwb',
+      }, validator, new Violation(property('password1'), 'ConfirmPassword')));
   });
 
   describe('recursive models', () => {
@@ -421,7 +428,10 @@ describe('objects', () => {
       },
     });
 
-    test('recursive type', () => expectValid({ first: 'first', next: { first: 'second', next: { first: 'third' } } }, validator));
+    test('recursive type', () => expectValid({
+      first: 'first',
+      next: { first: 'second', next: { first: 'third' } },
+    }, validator));
 
     test('cyclic data', async () => {
       const first: any = { first: 'first' };
@@ -436,6 +446,7 @@ describe('objects', () => {
       constructor(model: ObjectModel) {
         super(model);
       }
+
       validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
         return this.validateFilteredPath(value, path, ctx, _ => false);
       }
@@ -502,6 +513,18 @@ describe('objects', () => {
     test('123', () => expectValid(123, V.toObject('value'), { value: 123 }));
 
     test('object', () => expectValid({}, V.toObject('value')));
+  });
+
+  describe('notEmptyObject', async () => {
+    const optionalProps = ['x', 'y', 'z'];
+    test('invalid when undefined', () => expectViolations(undefined, V.notEmptyObject(), defaultViolations.notEmptyObject(undefined)));
+    test('invalid when null', () => expectViolations(null, V.notEmptyObject(), defaultViolations.notEmptyObject(null)));
+    test('invalid when empty object {}', () => expectViolations({}, V.notEmptyObject(), defaultViolations.notEmptyObject({})));
+    test('valid when value { foo: "bar" }', () => expectValid({ foo: 'bar' }, V.notEmptyObject(), { foo: 'bar' }));
+    test('invalid when []', () => expectViolations([], V.notEmptyObject(), defaultViolations.notEmptyObject([])));
+    test('invalid when 123', () => expectViolations(123, V.notEmptyObject(), defaultViolations.notEmptyObject(123)));
+    test('valid when optional props if provided', () => expectValid({ x: 2 }, V.notEmptyObject(optionalProps), { x: 2 }));
+    test('shows optional props in Violation output', () => expectViolations({}, V.notEmptyObject(optionalProps), defaultViolations.notEmptyObject({}, ROOT, optionalProps)));
   });
 });
 
@@ -571,11 +594,17 @@ describe('inheritance', () => {
 
   test('valid child', () => expectValid({ id: '123', name: 'child' }, childValidator));
 
-  test('valid child id', () => expectViolations({ id: 123, name: 'child' }, childValidator, defaultViolations.string(123, property('id'))));
+  test('valid child id', () => expectViolations({
+    id: 123,
+    name: 'child',
+  }, childValidator, defaultViolations.string(123, property('id'))));
 
   test('invalid parent property', () => expectViolations({ name: 'child' }, childValidator, defaultViolations.notNull(property('id'))));
 
-  test('invalid child property', () => expectViolations({ id: '123', name: '' }, childValidator, defaultViolations.notEmpty(property('name'))));
+  test('invalid child property', () => expectViolations({
+    id: '123',
+    name: '',
+  }, childValidator, defaultViolations.notEmpty(property('name'))));
 
   test('valid multi-parent object', () =>
     expectValid(
@@ -596,7 +625,7 @@ describe('inheritance', () => {
       defaultViolations.notNull(property('anything')),
     ));
 
-  test("child's extended property validators are only run after successful parent property validation", async () => {
+  test('child\'s extended property validators are only run after successful parent property validation', async () => {
     const type = V.object({
       extends: {
         properties: {
@@ -637,7 +666,10 @@ describe('object next', () => {
 
   test('passwords match', () => expectValid({ pw1: 'test', pw2: 'test' }, passwordValidator));
 
-  test('passwords mismatch', () => expectViolations({ pw1: 'test', pw2: 't3st' }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
+  test('passwords mismatch', () => expectViolations({
+    pw1: 'test',
+    pw2: 't3st',
+  }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
 
   test('run after property validators', () => expectViolations({ pw1: 'test' }, passwordValidator, defaultViolations.notNull(Path.of('pw2'))));
 
@@ -650,10 +682,18 @@ describe('object next', () => {
       next: V.assertTrue(user => user.pw1.indexOf(user.name) < 0, 'BadPassword', Path.of('pw1')),
     });
 
-    test('BadPassword', () => expectViolations({ pw1: 'test', pw2: 'test', name: 'tes' }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
+    test('BadPassword', () => expectViolations({
+      pw1: 'test',
+      pw2: 'test',
+      name: 'tes',
+    }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
 
     test('child next is applied after successfull parent next', () =>
-      expectViolations({ pw1: 'test', pw2: 't3st', name: 'tes' }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
+      expectViolations({
+        pw1: 'test',
+        pw2: 't3st',
+        name: 'tes',
+      }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
   });
 });
 
@@ -736,6 +776,7 @@ describe('Date', () => {
       }
       return ctx.success(value);
     }
+
     const validator = V.object({
       properties: {
         date: V.date().next(V.fn(notInstanceOfDate, 'NotInstanceOfDate')),
@@ -756,6 +797,7 @@ describe('enum', () => {
   enum StrEnum {
     A = 'A',
   }
+
   enum IntEnum {
     A,
   }
@@ -795,6 +837,7 @@ describe('oneOf', () => {
   enum EnumType {
     A = 'ABC',
   }
+
   describe('with conversion', () => {
     const validator = V.oneOf(V.hasValue('2019-01-24T09:10:00Z'), V.date(), V.enum(EnumType, 'EnumType'));
 
@@ -980,6 +1023,7 @@ describe('number', () => {
   describe('async', () => {
     class WaitValidator extends Validator {
       public executionOrder: any[] = [];
+
       async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<ValidationResult> {
         return new Promise<ValidationResult>((resolve, reject) => {
           setTimeout(() => {
@@ -989,12 +1033,13 @@ describe('number', () => {
         });
       }
     }
+
     test('should maintain original order even if execution order is reversed', async () => {
       const waitValidator = new WaitValidator();
-      await expectValid([50, 40, 30, 20, 10, 1], V.array(waitValidator))
-      expect(waitValidator.executionOrder).toEqual([1, 10, 20, 30, 40, 50])
-    })
-  })
+      await expectValid([50, 40, 30, 20, 10, 1], V.array(waitValidator));
+      expect(waitValidator.executionOrder).toEqual([1, 10, 20, 30, 40, 50]);
+    });
+  });
 });
 
 describe('null or undefined', () => {

--- a/packages/core/src/V.ts
+++ b/packages/core/src/V.ts
@@ -53,6 +53,7 @@ import {
   HasValueValidator,
   JsonValidator,
   RequiredValidator,
+  NotEmptyObjectValidator,
 } from './validators.js';
 
 const ignoreValidator = new IgnoreValidator(),
@@ -101,6 +102,8 @@ export const V = {
   nullOrUndefined: () => nullOrUndefinedValidator,
 
   notEmpty: () => notEmptyValidator,
+
+  notEmptyObject: (optionalProperties?: string[]) => new NotEmptyObjectValidator(optionalProperties),
 
   notBlank: () => notBlankValidator,
 


### PR DESCRIPTION
## Description of change
This PR introduces a new validation utility, `V.notEmptyObject()`, to our validation framework. This validator is specifically designed to ensure that the input it validates is a non-empty object, containing at least one key-value pair. It's a crucial addition to enhance the robustness of our input validation processes.

The primary function of `V.notEmptyObject()` is to check if the provided input is not just an object, but also that it is not empty. This is particularly useful in scenarios where we need to verify that an input object contains necessary data and is not just an empty shell. 

An important feature of this validator is its strictness in terms of input type. If the input passed is not an object, or if it is an empty object, the validation will fail, ensuring that only valid, non-empty objects pass through.

## Use Case Implementation

A practical implementation of this validator can be seen in the user password validation process. The `userValidator` defined in this PR employs `V.notEmptyObject()` followed by `V.object()` to validate the structure and content of the user password input. This ensures that the password object is not only present but also adheres to our specified constraints, like the required patterns and size for the password.

### Code Example

```javascript
const userValidator = V.notEmptyObject().next(V.object({
  properties: {
    password1: V.string().next(V.pattern(/[A-Z]/), V.pattern(/[a-z]/), V.pattern(/[0-9]/), V.size(8, 32)),
    password2: V.string(),
  },
}));
const result = await userValidator.validate({});
console.log(result.getViolations());
```
this will output:
```
[
  NotEmptyObjectViolation {
    path: Path { path: [] },
    type: 'NotEmptyObject',
    invalidValue: {}
  }
]
```
For the particular use case when user does not know what to expect, for instance if the validation is in front of an endpoint, the parameter `optionalProperties?: string[]` can be used to specify which properties the user may need to pass, but this doesn't make the properties required by no means, it is just an output for the validator. 
Let's see the below example to validate an empty object must be passed and the following properties may be missing: `['firstName', 'lastName']`
```typescript
const personValidator = V.notEmptyObject(['firstName', 'lastName']);
      const result = await personValidator.validate({});
      console.log(result.getViolations());
```
Expected output:
```
[
  NotEmptyObjectViolation {
    path: Path { path: [] },
    type: 'NotEmptyObject',
    invalidValue: {},
    optionalProperties: [ 'firstName', 'lastName' ]
  }
]
```

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context
We have been working on an important feature in our team that requires this validator or similar to be implemented. For example, when all properties of an object are optional, but at least one of them is required and we don't know which one is, it is important to have such validation option in place, and this validator solves the problem.

## How Has This Been Tested?
Added a bunch of tests in the code to check that this works as expected.

## Screenshots (if appropriate):