### PR TITLE
feat(NotEmptyValidator): improving notEmpty validator to work with empty strings, arrays and objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+/.idea/

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -168,16 +168,16 @@ const UserRegistrationValidator = V.object({
 
 ## Vhy?
 
-- Machine readable error reports
-  - V's Violation is easily readable to any developer and can be used to localize and target human readable error messages in the UI
+- Machine-readable error reports
+  - V's Violation is easily readable to any developer and can be used to localize and target human-readable error messages in the UI
   - Errors serialize to JSON nicely for easy interoperability
 - Asynchronous processing allows I/O based validators
   - E.g. check if a code or an ID exists
   - Basic validators are internally synchronous for better performance
 - Fluent syntax
 - Composability
-- Supports object oriented inheritance and polymorphism where as
-  - OpenAPI's inheritance and polymorpism mechanism is problematic if not broken alltogether
+- Supports object-oriented inheritance and polymorphism whereas
+  - OpenAPI's inheritance and polymorphism mechanism is problematic if not broken altogether
   - The latest draft of [JSON Schema (2019-09) doesn't support inheritance](https://github.com/json-schema-org/json-schema-org.github.io/issues/148)
 - Effortless custom extension
   - All non-trivial use cases require some custom validation logic
@@ -229,7 +229,7 @@ V.toInteger().next(V.min(1), V.max(1000), V.assertTrue(isPrime));
 
 ### Named Properties
 
-An object may have any named property defined in a parent `properties`, it's own `properties` or `localProperties`, which in turn are not inherited.
+An object may have any named property defined in a parent `properties`, its own `properties` or `localProperties`, which in turn are not inherited.
 
 A child model may extend the validation rules of any inherited properties. In such a case inherited property validators are executed first and, if success, the converted value is validated against child's property validators. A child may only further restrict parent's property rules.
 
@@ -310,7 +310,7 @@ const aircraft = V.object({
 
 This kind of use case where an object holds a mapping from identifiers (like enum) to values is so common that there's even a shortcut for it: `V.properties`.
 
-Note that `V.object` may explicitly _deny_ additional properties from it's submodels by setting `additionalProperties: false`, but this cannot block submodels from adding their own named properties.
+Note that `V.object` may explicitly _deny_ additional properties from its sub-models by setting `additionalProperties: false`, but this cannot block sub-models from adding their own named properties.
 Objects may have zero or more additional property validators which are invoked for all non-named properties.
 
 All additional-property-validators consist of two parts, key and value validator. For a non-named property there must be at least one additional-property-validator
@@ -332,7 +332,7 @@ Arrays are defined in terms of their element type:
 V.array(V.integer()).next(V.size(1, 100)); // An integer array of size 1 to 100
 ```
 
-Note that basic validators do not handle polymoprhism even though they support inheritance. For example this definition would not validate elements against `bike` or `aircraft`:
+Note that basic validators do not handle polymorphism even though they support inheritance. For example this definition would not validate elements against `bike` or `aircraft`:
 
 ```typescript
 V.array(vehicle);
@@ -340,11 +340,11 @@ V.array(vehicle);
 
 ## <a name="schema">Schema</a>
 
-Polymorphims requires that objects are somehow tagged with a type used to validate it. Since plain JSON/JavaScript objects do not have type information attached to them
+Polymorphism requires that objects are somehow tagged with a type used to validate it. Since plain JSON/JavaScript objects do not have type information attached to them
 one needs a _discriminator_ property or a function to infer object's type. This type is then used to actually validate the object.
 
-Polymorphic schemas are recursive in nature: 1) a child needs to know it's parents so that it may extend them and 2) unless the type information is natively bound to
-the object being validated, the parent needs to know it's children so that it may dispatch the validation to the correct child. As (direct) cyclic references are not possible, SchemaValidator is created with a callback function that supports referencing other models within the schema by name
+Polymorphic schemas are recursive in nature: 1) a child needs to know its parents so that it may extend them and 2) unless the type information is natively bound to
+the object being validated, the parent needs to know its children so that it may dispatch the validation to the correct child. As (direct) cyclic references are not possible, SchemaValidator is created with a callback function that supports referencing other models within the schema by name
 even before they are defined:
 
 1. An object may extend other models by simply referencing them by name.
@@ -460,15 +460,15 @@ V.mapType(keys, values, false);
 ## Validator Options
 
 `V` supports contextual validation options which can be used to guide validation.
-Options are passed to to `validate` function as optional second argument.
+Options are passed to `validate` function as optional second argument.
 
 | Option                            | Description                                |
-| --------------------------------- | ------------------------------------------ |
-| ignoreUnknownProperties?: boolean | Unknown properties allowed by default.\*   |
+|-----------------------------------|--------------------------------------------|
+| ignoreUnknownProperties?: boolean | Unknown properties allowed by default.     |
 | ignoreUnknownEnumValues?: boolean | Unknown enum values allowed by default     |
 | warnLogger?: WarnLogger           | A reporter function for ignored Violations |
 | group?: Group                     | A group used to activate validation rules  |
-| allowCycles?: boolean             | Multiple references to same object allowed |
+| allowCycles?: boolean             | Multiple references to same object allowed |
 
 \*) Note that this option has no effect in cases where additional properties are explicitly denied.
 
@@ -525,61 +525,61 @@ class MyViolation extends Violation {
 
 Unless otherwise stated, all validators require non-null and non-undefined values.
 
-| V.                      | Arguments                                                        | Description                                                                                                                                |
-| ----------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| fn                      |  fn: ValidatorFn, type?: string                                  | Function reference as a validator. A short cut for extending Validator class.                                                              |
-| ignore                  |                                                                  | Converts any input value to undefined.                                                                                                     |
-| any                     |                                                                  | Accepts any value, including undefined and null.                                                                                           |
-| check                   | ...allOf: Validator[]                                            | Runs all the validators and, if successful, returns the original value discarding any conversions.                                         |
-| map                     | fn: MappingFn, error?: any                                       | Mapping function to convert a value. Catches and converts errors to Violations                                                             |
-| optional                | type: Validator, ...allOf: Validator[]                           | Allows null and undefined. For other values, runs first the `type` validator and then `allOf` the rest validators.                         |
-| required                | type: Validator, ...allOf: Validator[]                           | 1) Requires a non-null and non-undefined value, 2) runs `type` validator and 3) then `allOf` the rest validators.                          |
-| string                  |                                                                  | Requires string or String.                                                                                                                 |
-| toString                |                                                                  | Converts primitive values to (primitive) strings.                                                                                          |
-| notNull                 |                                                                  | Requires non-null and non-undefined value.                                                                                                 |
-| nullOrUndefined         |                                                                  | Requires null or undefined value.                                                                                                          |
-| notEmpty                |                                                                  | Requires non-null, non-undefined and not empty. Works with anything having numeric `length` property, e.g. string or array.                |
-| notBlank                |                                                                  | Requires non-null, non-undefined and not blank (whitespace only string) values.                                                            |
-| uuid                    | version?: number                                                 | Uses `uuid-validate` package to validate input.                                                                                            |
-| pattern                 |  pattern: string \| RegExp, flags?: string                       | Tests input against the pattern.                                                                                                           |
-| toPattern               |                                                                  | Combines `toString` normalization with pattern validator.                                                                                  |
-| boolean                 |                                                                  | Requires that input is primitive boolean.                                                                                                  |
-| toBoolean               | truePattern?: RegExp, falsePattern?: RegExp                      | Converts strings and numbers to boolean. Patterns for true and false can be configured using regexp, defaults to true and false.           |
-| number                  |                                                                  | Requires that input is either primitive number or Number and not NaN.                                                                      |
-| toNumber                |                                                                  | Converts numeric strings to numbers.                                                                                                       |
-| integer                 |                                                                  |  Requires that input is integer.                                                                                                           |
-| toInteger               |                                                                  | Converts numeric strings to integers.                                                                                                      |
-| min                     | min: number, inclusive = true                                    | Asserts that numeric input is greater than or equal (if inclusive = true) than `min`.                                                      |
-| max                     | max: number, inclusive = true                                    | Asserts that numeric input is less than or equal (if inclusive = true) than `max`.                                                         |
-| date                    |                                                                  | Reqruires a valid date. Converts string to Date.                                                                                           |
-| enum                    | enumType: object, name: string                                   | Requires that the input is one of given enumType. Name of the enum provided for error message.                                             |
-| assertTrue              | fn: AssertTrue, type: string = 'AssertTrue', path?: Path         | Requires that the input passes `fn`. Type can be provided for error messages and path to target a sub property                             |
-| hasValue                | expectedValue: any                                               | Requires that the input matches `expectedValue`. Uses `node-deep-equal` library.                                                           |
-| object                  | model: Model                                                     | Defines an [Object validator](#object) based on provided Model.                                                                            |
-| toObject                | property: string                                                 | Converts a primitive value to object `{ property: 'value' }`. Undefined is passed on as such.                                              |
-| schema                  | callback: (schema: SchemaValidator) => SchemaModel               | Defines a [SchemaValidator](#schema) for a discriminator and models.                                                                       |
-| properties              | keys: Validator \| Validator[], values: Validator \| Validator[] | A shortcut for object with `additionalProperties`.                                                                                         |
-| mapType                 | keys: Validator, values: Validator, jsonSafeMap: boolean = true  | [Map validator](#map)                                                                                                                      |
-| toMapType(keys, values) | keys: Validator, values: Validator                               | Converts an array-of-arrays representation of a Map into a JsonSafeMap instance.                                                           |
-| array                   | ...items: Validator[]                                            | [Array validator](#array)                                                                                                                  |
-| toArray                 | items: Validator                                                 | Converts undefined to an empty array and non-arrays to single-valued arrays.                                                               |
-| size                    | min: number, max: number                                         |  Asserts that input's numeric `length` property is between min and max (both inclusive).                                                   |
-| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. Validators are run in parallel and in case they convert the input, all must provide same output. |
-| anyOf                   | ...validators: Validator[]                                       | Requires minimum one of given validators matches. Validators are run in parallel and in case of failure, all violations will be returned.  |
-| oneOf                   | ...validators: Validator[]                                       | Requires that exactly one of the given validators match.                                                                                   |
-| compositionOf           | ...validators: Validator[]                                       | Runs given the validators one after another, chaining the result.                                                                          |
-| emptyToUndefined        |                                                                  | Converts null or empty string to undefined. Does not touch any other values.                                                               |
-| emptyToNull             |                                                                  | Converts undefined or empty string to null. Does not touch any other values.                                                               |
-| emptyTo                 | defaultValue: string                                             | Uses given `defaultValue` in place of null, undefined or empty string. Does not touch any other values.                                    |
-| nullTo                  | defaultValue: string                                             | Uses given `defaultValue` in place of null. Does not touch any other values.                                                               |
-| undefinedToNull         |                                                                  | Convets undefined to null. Does not touch any other values.                                                                                |
-| if...elseif...else      | fn: AssertTrue, ...allOf: Validator[]                            | Configures validators (`allOf`) to be executed for cases where if/elseif AssertTrue fn returns true.                                       |
-| whenGroup...otherwise   | group: GroupOrName, ...allOf: Validator[]                        | Defines validation rules (`allOf`) to be executed for given `ValidatorOptions.group`.                                                      |
-| json                    | ...validators: Validator[]                                       | Parse JSON input and validate it against given validators.                                                                                 |
+| V.                      | Arguments                                                        | Description                                                                                                                                          |
+|-------------------------|------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| fn                      | fn: ValidatorFn, type?: string                                   | Function reference as a validator. A short cut for extending Validator class.                                                                        |
+| ignore                  |                                                                  | Converts any input value to undefined.                                                                                                               |
+| any                     |                                                                  | Accepts any value, including undefined and null.                                                                                                     |
+| check                   | ...allOf: Validator[]                                            | Runs all the validators and, if successful, returns the original value discarding any conversions.                                                   |
+| map                     | fn: MappingFn, error?: any                                       | Mapping function to convert a value. Catches and converts errors to Violations                                                                       |
+| optional                | type: Validator, ...allOf: Validator[]                           | Allows null and undefined. For other values, runs first the `type` validator and then `allOf` the rest validators.                                   |
+| required                | type: Validator, ...allOf: Validator[]                           | 1) Requires a non-null and non-undefined value, 2) runs `type` validator and 3) then `allOf` the rest validators.                                    |
+| string                  |                                                                  | Requires string or String.                                                                                                                           |
+| toString                |                                                                  | Converts primitive values to (primitive) strings.                                                                                                    |
+| notNull                 |                                                                  | Requires non-null and non-undefined value.                                                                                                           |
+| nullOrUndefined         |                                                                  | Requires null or undefined value.                                                                                                                    |
+| notEmpty                |                                                                  | Requires non-null, non-undefined and not empty. Works with `string`, `null`, `undefined`, `arrays`, `objects` and anything having a numeric length.  |
+| notBlank                |                                                                  | Requires non-null, non-undefined and not blank (whitespace only string) values.                                                                      |
+| uuid                    | version?: number                                                 | Uses `uuid-validate` package to validate input.                                                                                                      |
+| pattern                 | pattern: string \| RegExp, flags?: string                        | Tests input against the pattern.                                                                                                                     |
+| toPattern               |                                                                  | Combines `toString` normalization with pattern validator.                                                                                            |
+| boolean                 |                                                                  | Requires that input is primitive boolean.                                                                                                            |
+| toBoolean               | truePattern?: RegExp, falsePattern?: RegExp                      | Converts strings and numbers to boolean. Patterns for true and false can be configured using regexp, defaults to true and false.                     |
+| number                  |                                                                  | Requires that input is either primitive number or Number and not NaN.                                                                                |
+| toNumber                |                                                                  | Converts numeric strings to numbers.                                                                                                                 |
+| integer                 |                                                                  | Requires that input is integer.                                                                                                                      |
+| toInteger               |                                                                  | Converts numeric strings to integers.                                                                                                                |
+| min                     | min: number, inclusive = true                                    | Asserts that numeric input is greater than or equal (if inclusive = true) than `min`.                                                                |
+| max                     | max: number, inclusive = true                                    | Asserts that numeric input is less than or equal (if inclusive = true) than `max`.                                                                   |
+| date                    |                                                                  | Requires a valid date. Converts string to Date.                                                                                                      |
+| enum                    | enumType: object, name: string                                   | Requires that the input is one of given enumType. Name of the enum provided for error message.                                                       |
+| assertTrue              | fn: AssertTrue, type: string = 'AssertTrue', path?: Path         | Requires that the input passes `fn`. Type can be provided for error messages and path to target a sub property                                       |
+| hasValue                | expectedValue: any                                               | Requires that the input matches `expectedValue`. Uses `node-deep-equal` library.                                                                     |
+| object                  | model: Model                                                     | Defines an [Object validator](#object) based on provided Model.                                                                                      |
+| toObject                | property: string                                                 | Converts a primitive value to object `{ property: 'value' }`. Undefined is passed on as such.                                                        |
+| schema                  | callback: (schema: SchemaValidator) => SchemaModel               | Defines a [SchemaValidator](#schema) for a discriminator and models.                                                                                 |
+| properties              | keys: Validator \| Validator[], values: Validator \| Validator[] | A shortcut for object with `additionalProperties`.                                                                                                   |
+| mapType                 | keys: Validator, values: Validator, jsonSafeMap: boolean = true  | [Map validator](#map)                                                                                                                                |
+| toMapType(keys, values) | keys: Validator, values: Validator                               | Converts an array-of-arrays representation of a Map into a JsonSafeMap instance.                                                                     |
+| array                   | ...items: Validator[]                                            | [Array validator](#array)                                                                                                                            |
+| toArray                 | items: Validator                                                 | Converts undefined to an empty array and non-arrays to single-valued arrays.                                                                         |
+| size                    | min: number, max: number                                         | Asserts that input's numeric `length` property is between min and max (both inclusive).                                                              |
+| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. Validators are run in parallel and in case they convert the input, all must provide same output.           |
+| anyOf                   | ...validators: Validator[]                                       | Requires minimum one of given validators matches. Validators are run in parallel and in case of failure, all violations will be returned.            |
+| oneOf                   | ...validators: Validator[]                                       | Requires that exactly one of the given validators match.                                                                                             |
+| compositionOf           | ...validators: Validator[]                                       | Runs given the validators one after another, chaining the result.                                                                                    |
+| emptyToUndefined        |                                                                  | Converts null or empty string to undefined. Does not touch any other values.                                                                         |
+| emptyToNull             |                                                                  | Converts undefined or empty string to null. Does not touch any other values.                                                                         |
+| emptyTo                 | defaultValue: string                                             | Uses given `defaultValue` in place of null, undefined or empty string. Does not touch any other values.                                              |
+| nullTo                  | defaultValue: string                                             | Uses given `defaultValue` in place of null. Does not touch any other values.                                                                         |
+| undefinedToNull         |                                                                  | Converts undefined to null. Does not touch any other values.                                                                                         |
+| if...elseif...else      | fn: AssertTrue, ...allOf: Validator[]                            | Configures validators (`allOf`) to be executed for cases where if/elseif AssertTrue fn returns true.                                                 |
+| whenGroup...otherwise   | group: GroupOrName, ...allOf: Validator[]                        | Defines validation rules (`allOf`) to be executed for given `ValidatorOptions.group`.                                                                |
+| json                    | ...validators: Validator[]                                       | Parse JSON input and validate it against given validators.                                                                                           |
 
 ## Violations
 
-All `Violations` have following propertie in common:
+All `Violations` have the following properties in common:
 
 | Property           | Description                                                                                                                                                                                          |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -591,23 +591,23 @@ All `Violations` have following propertie in common:
 
 ### Built-in Violations
 
-| Class                  | Type                  | Properties                       | Description                                                                         |
-| ---------------------- | --------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
-| TypeMismatch           | TypeMismatch          | expected: string                 | Type mismatch: `expected` is a description of expected type.                        |
-| EnumMismatch           | EnumMismatch          | enumType: string                 | Invalid enum value: `enumType` is the name of the expected enumeration.             |
-| ErrorViolation         | Error                 | error: any                       | An unspecified Error that was thrown and caught.                                    |
-| HasValueViolation      | HasValue              | expectedValue: any               | Input does not match (deepEqual) expectedValue.                                     |
-| PatternViolationi      | Pattern               | pattern: string                  | Input does not match the regular expression (pattern).                              |
-| OneOfMismatch          | OneOf                 | matches: number                  | Input matches 0 or >= 2 of the configured validators.                               |
-| MaxViolation           | Max                   | max: number, inclusive: boolean  | Input is greater-than or greater-than-or-equal, if `inclusive=true`, than `max`.    |
-| MinViolation           | Min                   |  min: number, inclusive: boolean | Input is less-than or less-than-or-equal if inclusive=true than `min`.              |
-| SizeViolation          | Size                  | min: number, max: number         | Input `length` (required numeric property) is less-than `min` or grater-than `max`. |
-| Violation              | NotNull               |                                  | Input is `null` or `undefined`.                                                     |
-| Violation              | NotEmpty              |                                  | Input is `null`, `undefined` or empty (i.e. input.length === 0).                    |
-| Violation              | NotBlank              |                                  | Input (string) is `null`, `undefined` or empty when trimmed.                        |
-| Violation              | UnknownProperty       |                                  | Additional property that is denied by default (see ignoreUnknownProperties).        |
-| Violation              | UnknownPropertyDenied |                                  | Explicitly denied additional property.                                              |
-| DiscriminatorViolation | Discriminator         | expectedOneOf: string[]          | Invalid discriminator value: `expectedOneOf` is a list of known types.              |
+| Class                  | Type                  | Properties                      | Description                                                                         |
+|------------------------|-----------------------|---------------------------------|-------------------------------------------------------------------------------------|
+| TypeMismatch           | TypeMismatch          | expected: string                | Type mismatch: `expected` is a description of expected type.                        |
+| EnumMismatch           | EnumMismatch          | enumType: string                | Invalid enum value: `enumType` is the name of the expected enumeration.             |
+| ErrorViolation         | Error                 | error: any                      | An unspecified Error that was thrown and caught.                                    |
+| HasValueViolation      | HasValue              | expectedValue: any              | Input does not match (deepEqual) expectedValue.                                     |
+| PatternViolation       | Pattern               | pattern: string                 | Input does not match the regular expression (pattern).                              |
+| OneOfMismatch          | OneOf                 | matches: number                 | Input matches 0 or >= 2 of the configured validators.                               |
+| MaxViolation           | Max                   | max: number, inclusive: boolean | Input is greater-than or greater-than-or-equal, if `inclusive=true`, than `max`.    |
+| MinViolation           | Min                   | min: number, inclusive: boolean | Input is less-than or less-than-or-equal if inclusive=true than `min`.              |
+| SizeViolation          | Size                  | min: number, max: number        | Input `length` (required numeric property) is less-than `min` or grater-than `max`. |
+| Violation              | NotNull               |                                 | Input is `null` or `undefined`.                                                     |
+| Violation              | NotEmpty              |                                 | Input is `null`, `undefined`, `empty objects` or empty (i.e. input.length === 0).   |
+| Violation              | NotBlank              |                                 | Input (string) is `null`, `undefined` or empty when trimmed.                        |
+| Violation              | UnknownProperty       |                                 | Additional property that is denied by default (see ignoreUnknownProperties).        |
+| Violation              | UnknownPropertyDenied |                                 | Explicitly denied additional property.                                              |
+| DiscriminatorViolation | Discriminator         | expectedOneOf: string[]         | Invalid discriminator value: `expectedOneOf` is a list of known types.              |
 
 ## Roadmap
 

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect } from 'vitest';
 import {
   Validator,
   Violation,
@@ -359,7 +359,7 @@ describe('objects', () => {
 
     test('parent conversion is available for child validator', () => expectValid({ foo: '1' }, validator, { foo: 1 }));
 
-    test("invalid value for parent doesn't run child validator", () =>
+    test('invalid value for parent doesn\'t run child validator', () =>
       expectViolations({ foo: 'a' }, validator, defaultViolations.number('a', NumberFormat.integer, property('foo'))));
 
     test('invalid value for child validator', () => expectViolations({ foo: 0 }, validator, defaultViolations.min(1, true, 0, property('foo'))));
@@ -384,6 +384,7 @@ describe('objects', () => {
       password1: string;
       password2: string;
     }
+
     class PasswordRequest implements IPasswordRequest {
       password1: string;
 
@@ -407,10 +408,16 @@ describe('objects', () => {
     );
 
     test('matching passwords', async () =>
-      await expectValid({ password1: 'pwd', password2: 'pwd' }, validator, new PasswordRequest({ password1: 'pwd', password2: 'pwd' })));
+      await expectValid({ password1: 'pwd', password2: 'pwd' }, validator, new PasswordRequest({
+        password1: 'pwd',
+        password2: 'pwd',
+      })));
 
     test('non-matching passwords', async () =>
-      await expectViolations({ password1: 'pwd', password2: 'pwb' }, validator, new Violation(property('password1'), 'ConfirmPassword')));
+      await expectViolations({
+        password1: 'pwd',
+        password2: 'pwb',
+      }, validator, new Violation(property('password1'), 'ConfirmPassword')));
   });
 
   describe('recursive models', () => {
@@ -421,7 +428,10 @@ describe('objects', () => {
       },
     });
 
-    test('recursive type', () => expectValid({ first: 'first', next: { first: 'second', next: { first: 'third' } } }, validator));
+    test('recursive type', () => expectValid({
+      first: 'first',
+      next: { first: 'second', next: { first: 'third' } },
+    }, validator));
 
     test('cyclic data', async () => {
       const first: any = { first: 'first' };
@@ -436,6 +446,7 @@ describe('objects', () => {
       constructor(model: ObjectModel) {
         super(model);
       }
+
       validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
         return this.validateFilteredPath(value, path, ctx, _ => false);
       }
@@ -571,11 +582,17 @@ describe('inheritance', () => {
 
   test('valid child', () => expectValid({ id: '123', name: 'child' }, childValidator));
 
-  test('valid child id', () => expectViolations({ id: 123, name: 'child' }, childValidator, defaultViolations.string(123, property('id'))));
+  test('valid child id', () => expectViolations({
+    id: 123,
+    name: 'child',
+  }, childValidator, defaultViolations.string(123, property('id'))));
 
   test('invalid parent property', () => expectViolations({ name: 'child' }, childValidator, defaultViolations.notNull(property('id'))));
 
-  test('invalid child property', () => expectViolations({ id: '123', name: '' }, childValidator, defaultViolations.notEmpty(property('name'))));
+  test('invalid child property', () => expectViolations({
+    id: '123',
+    name: '',
+  }, childValidator, defaultViolations.notEmpty(property('name'))));
 
   test('valid multi-parent object', () =>
     expectValid(
@@ -596,7 +613,7 @@ describe('inheritance', () => {
       defaultViolations.notNull(property('anything')),
     ));
 
-  test("child's extended property validators are only run after successful parent property validation", async () => {
+  test('child\'s extended property validators are only run after successful parent property validation', async () => {
     const type = V.object({
       extends: {
         properties: {
@@ -637,7 +654,10 @@ describe('object next', () => {
 
   test('passwords match', () => expectValid({ pw1: 'test', pw2: 'test' }, passwordValidator));
 
-  test('passwords mismatch', () => expectViolations({ pw1: 'test', pw2: 't3st' }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
+  test('passwords mismatch', () => expectViolations({
+    pw1: 'test',
+    pw2: 't3st',
+  }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
 
   test('run after property validators', () => expectViolations({ pw1: 'test' }, passwordValidator, defaultViolations.notNull(Path.of('pw2'))));
 
@@ -650,10 +670,18 @@ describe('object next', () => {
       next: V.assertTrue(user => user.pw1.indexOf(user.name) < 0, 'BadPassword', Path.of('pw1')),
     });
 
-    test('BadPassword', () => expectViolations({ pw1: 'test', pw2: 'test', name: 'tes' }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
+    test('BadPassword', () => expectViolations({
+      pw1: 'test',
+      pw2: 'test',
+      name: 'tes',
+    }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
 
     test('child next is applied after successfull parent next', () =>
-      expectViolations({ pw1: 'test', pw2: 't3st', name: 'tes' }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
+      expectViolations({
+        pw1: 'test',
+        pw2: 't3st',
+        name: 'tes',
+      }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
   });
 });
 
@@ -736,6 +764,7 @@ describe('Date', () => {
       }
       return ctx.success(value);
     }
+
     const validator = V.object({
       properties: {
         date: V.date().next(V.fn(notInstanceOfDate, 'NotInstanceOfDate')),
@@ -756,6 +785,7 @@ describe('enum', () => {
   enum StrEnum {
     A = 'A',
   }
+
   enum IntEnum {
     A,
   }
@@ -795,6 +825,7 @@ describe('oneOf', () => {
   enum EnumType {
     A = 'ABC',
   }
+
   describe('with conversion', () => {
     const validator = V.oneOf(V.hasValue('2019-01-24T09:10:00Z'), V.date(), V.enum(EnumType, 'EnumType'));
 
@@ -980,6 +1011,7 @@ describe('number', () => {
   describe('async', () => {
     class WaitValidator extends Validator {
       public executionOrder: any[] = [];
+
       async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<ValidationResult> {
         return new Promise<ValidationResult>((resolve, reject) => {
           setTimeout(() => {
@@ -989,12 +1021,86 @@ describe('number', () => {
         });
       }
     }
+
     test('should maintain original order even if execution order is reversed', async () => {
       const waitValidator = new WaitValidator();
-      await expectValid([50, 40, 30, 20, 10, 1], V.array(waitValidator))
-      expect(waitValidator.executionOrder).toEqual([1, 10, 20, 30, 40, 50])
-    })
-  })
+      await expectValid([50, 40, 30, 20, 10, 1], V.array(waitValidator));
+      expect(waitValidator.executionOrder).toEqual([1, 10, 20, 30, 40, 50]);
+    });
+  });
+});
+
+describe('notEmpty', () => {
+  describe('valid cases', () => {
+    test('valid string input', async () => {
+      await expectValid('abc', V.notEmpty(), 'abc');
+    });
+
+    test('valid number input', async () => {
+      await expectValid(123, V.notEmpty(), 123);
+    });
+
+    test('valid object input', async () => {
+      await expectValid({ foo: 'bar' }, V.notEmpty(), { foo: 'bar' });
+    });
+
+    test('valid array input', async () => {
+      await expectValid([1, 2, 3], V.notEmpty(), [1, 2, 3]);
+    });
+
+    test('valid boolean input', async () => {
+      await expectValid(true, V.notEmpty(), true);
+    });
+  });
+
+  describe('invalid cases', () => {
+    test('validates undefined input', async () => {
+      await expectViolations(undefined, V.notEmpty(), defaultViolations.notEmpty(ROOT, undefined));
+    });
+
+    test('validates null input', async () => {
+      await expectViolations(null, V.notEmpty(), defaultViolations.notEmpty(ROOT, null));
+    });
+
+    test('validates empty string input', async () => {
+      await expectViolations('', V.notEmpty(), defaultViolations.notEmpty(ROOT, ''));
+    });
+
+    test('validates empty array input', async () => {
+      await expectViolations([], V.notEmpty(), defaultViolations.notEmpty(ROOT, []));
+    });
+
+    test('validates empty object input', async () => {
+      await expectViolations({}, V.notEmpty(), defaultViolations.notEmpty(ROOT, {}));
+    });
+
+    test('validates prototyped objects with inherited properties, not own ones', async () => {
+      const myObject = Object.create({
+        foo: 'This is an inherited property'
+      });
+
+      await expectViolations(myObject, V.notEmpty(), defaultViolations.notEmpty(ROOT, myObject));
+    });
+
+    test('validates corner case prototyped objects having an inherited property length > 0', async () => {
+      const myObject = Object.create({
+        length: 5
+      });
+
+      await expectViolations(myObject, V.notEmpty(), defaultViolations.notEmpty(ROOT, myObject));
+    });
+  });
+});
+
+describe('next', () => {
+  const validator = defer(V.string()).next(defer(V.hasValue('true')));
+  test('valid', async () => {
+    await expectValid('true', validator);
+  });
+
+  test('invalid', async () => {
+    await expectViolations(true, validator, defaultViolations.string(true));
+  });
 });
 
 describe('null or undefined', () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest'
 import {
   Validator,
   Violation,
@@ -359,7 +359,7 @@ describe('objects', () => {
 
     test('parent conversion is available for child validator', () => expectValid({ foo: '1' }, validator, { foo: 1 }));
 
-    test('invalid value for parent doesn\'t run child validator', () =>
+    test("invalid value for parent doesn't run child validator", () =>
       expectViolations({ foo: 'a' }, validator, defaultViolations.number('a', NumberFormat.integer, property('foo'))));
 
     test('invalid value for child validator', () => expectViolations({ foo: 0 }, validator, defaultViolations.min(1, true, 0, property('foo'))));
@@ -408,16 +408,10 @@ describe('objects', () => {
     );
 
     test('matching passwords', async () =>
-      await expectValid({ password1: 'pwd', password2: 'pwd' }, validator, new PasswordRequest({
-        password1: 'pwd',
-        password2: 'pwd',
-      })));
+      await expectValid({ password1: 'pwd', password2: 'pwd' }, validator, new PasswordRequest({ password1: 'pwd', password2: 'pwd' })));
 
     test('non-matching passwords', async () =>
-      await expectViolations({
-        password1: 'pwd',
-        password2: 'pwb',
-      }, validator, new Violation(property('password1'), 'ConfirmPassword')));
+      await expectViolations({ password1: 'pwd', password2: 'pwb' }, validator, new Violation(property('password1'), 'ConfirmPassword')));
   });
 
   describe('recursive models', () => {
@@ -428,10 +422,7 @@ describe('objects', () => {
       },
     });
 
-    test('recursive type', () => expectValid({
-      first: 'first',
-      next: { first: 'second', next: { first: 'third' } },
-    }, validator));
+    test('recursive type', () => expectValid({ first: 'first', next: { first: 'second', next: { first: 'third' } } }, validator));
 
     test('cyclic data', async () => {
       const first: any = { first: 'first' };
@@ -582,17 +573,11 @@ describe('inheritance', () => {
 
   test('valid child', () => expectValid({ id: '123', name: 'child' }, childValidator));
 
-  test('valid child id', () => expectViolations({
-    id: 123,
-    name: 'child',
-  }, childValidator, defaultViolations.string(123, property('id'))));
+  test('valid child id', () => expectViolations({ id: 123, name: 'child' }, childValidator, defaultViolations.string(123, property('id'))));
 
   test('invalid parent property', () => expectViolations({ name: 'child' }, childValidator, defaultViolations.notNull(property('id'))));
 
-  test('invalid child property', () => expectViolations({
-    id: '123',
-    name: '',
-  }, childValidator, defaultViolations.notEmpty(property('name'))));
+  test('invalid child property', () => expectViolations({ id: '123', name: '' }, childValidator, defaultViolations.notEmpty(property('name'))));
 
   test('valid multi-parent object', () =>
     expectValid(
@@ -613,7 +598,7 @@ describe('inheritance', () => {
       defaultViolations.notNull(property('anything')),
     ));
 
-  test('child\'s extended property validators are only run after successful parent property validation', async () => {
+  test("child's extended property validators are only run after successful parent property validation", async () => {
     const type = V.object({
       extends: {
         properties: {
@@ -654,10 +639,7 @@ describe('object next', () => {
 
   test('passwords match', () => expectValid({ pw1: 'test', pw2: 'test' }, passwordValidator));
 
-  test('passwords mismatch', () => expectViolations({
-    pw1: 'test',
-    pw2: 't3st',
-  }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
+  test('passwords mismatch', () => expectViolations({ pw1: 'test', pw2: 't3st' }, passwordValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
 
   test('run after property validators', () => expectViolations({ pw1: 'test' }, passwordValidator, defaultViolations.notNull(Path.of('pw2'))));
 
@@ -670,18 +652,10 @@ describe('object next', () => {
       next: V.assertTrue(user => user.pw1.indexOf(user.name) < 0, 'BadPassword', Path.of('pw1')),
     });
 
-    test('BadPassword', () => expectViolations({
-      pw1: 'test',
-      pw2: 'test',
-      name: 'tes',
-    }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
+    test('BadPassword', () => expectViolations({ pw1: 'test', pw2: 'test', name: 'tes' }, userValidator, new Violation(Path.of('pw1'), 'BadPassword')));
 
     test('child next is applied after successfull parent next', () =>
-      expectViolations({
-        pw1: 'test',
-        pw2: 't3st',
-        name: 'tes',
-      }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
+      expectViolations({ pw1: 'test', pw2: 't3st', name: 'tes' }, userValidator, new Violation(Path.of('pw2'), 'PasswordVerification')));
   });
 });
 
@@ -1024,82 +998,71 @@ describe('number', () => {
 
     test('should maintain original order even if execution order is reversed', async () => {
       const waitValidator = new WaitValidator();
-      await expectValid([50, 40, 30, 20, 10, 1], V.array(waitValidator));
-      expect(waitValidator.executionOrder).toEqual([1, 10, 20, 30, 40, 50]);
-    });
-  });
-});
+      await expectValid([50, 40, 30, 20, 10, 1], V.array(waitValidator))
+      expect(waitValidator.executionOrder).toEqual([1, 10, 20, 30, 40, 50])
+    })
+  })
 
-describe('notEmpty', () => {
-  describe('valid cases', () => {
-    test('valid string input', async () => {
-      await expectValid('abc', V.notEmpty(), 'abc');
-    });
-
-    test('valid number input', async () => {
-      await expectValid(123, V.notEmpty(), 123);
-    });
-
-    test('valid object input', async () => {
-      await expectValid({ foo: 'bar' }, V.notEmpty(), { foo: 'bar' });
-    });
-
-    test('valid array input', async () => {
-      await expectValid([1, 2, 3], V.notEmpty(), [1, 2, 3]);
-    });
-
-    test('valid boolean input', async () => {
-      await expectValid(true, V.notEmpty(), true);
-    });
-  });
-
-  describe('invalid cases', () => {
-    test('validates undefined input', async () => {
-      await expectViolations(undefined, V.notEmpty(), defaultViolations.notEmpty(ROOT, undefined));
-    });
-
-    test('validates null input', async () => {
-      await expectViolations(null, V.notEmpty(), defaultViolations.notEmpty(ROOT, null));
-    });
-
-    test('validates empty string input', async () => {
-      await expectViolations('', V.notEmpty(), defaultViolations.notEmpty(ROOT, ''));
-    });
-
-    test('validates empty array input', async () => {
-      await expectViolations([], V.notEmpty(), defaultViolations.notEmpty(ROOT, []));
-    });
-
-    test('validates empty object input', async () => {
-      await expectViolations({}, V.notEmpty(), defaultViolations.notEmpty(ROOT, {}));
-    });
-
-    test('validates prototyped objects with inherited properties, not own ones', async () => {
-      const myObject = Object.create({
-        foo: 'This is an inherited property'
+  describe('notEmpty', () => {
+    describe('valid cases', () => {
+      test('valid string input', async () => {
+        await expectValid('abc', V.notEmpty(), 'abc');
       });
 
-      await expectViolations(myObject, V.notEmpty(), defaultViolations.notEmpty(ROOT, myObject));
-    });
-
-    test('validates corner case prototyped objects having an inherited property length > 0', async () => {
-      const myObject = Object.create({
-        length: 5
+      test('valid number input', async () => {
+        await expectValid(123, V.notEmpty(), 123);
       });
 
-      await expectViolations(myObject, V.notEmpty(), defaultViolations.notEmpty(ROOT, myObject));
+      test('valid object input', async () => {
+        await expectValid({ foo: 'bar' }, V.notEmpty(), { foo: 'bar' });
+      });
+
+      test('valid array input', async () => {
+        await expectValid([1, 2, 3], V.notEmpty(), [1, 2, 3]);
+      });
+
+      test('valid boolean input', async () => {
+        await expectValid(true, V.notEmpty(), true);
+      });
     });
-  });
-});
 
-describe('next', () => {
-  const validator = defer(V.string()).next(defer(V.hasValue('true')));
-  test('valid', async () => {
-    await expectValid('true', validator);
-  });
+    describe('invalid cases', () => {
+      test('validates undefined input', async () => {
+        await expectViolations(undefined, V.notEmpty(), defaultViolations.notEmpty(ROOT, undefined));
+      });
 
-  test('invalid', async () => {
-    await expectViolations(true, validator, defaultViolations.string(true));
+      test('validates null input', async () => {
+        await expectViolations(null, V.notEmpty(), defaultViolations.notEmpty(ROOT, null));
+      });
+
+      test('validates empty string input', async () => {
+        await expectViolations('', V.notEmpty(), defaultViolations.notEmpty(ROOT, ''));
+      });
+
+      test('validates empty array input', async () => {
+        await expectViolations([], V.notEmpty(), defaultViolations.notEmpty(ROOT, []));
+      });
+
+      test('validates empty object input', async () => {
+        await expectViolations({}, V.notEmpty(), defaultViolations.notEmpty(ROOT, {}));
+      });
+
+      test('validates prototyped objects with inherited properties, not own ones', async () => {
+        const myObject = Object.create({
+          foo: 'This is an inherited property',
+        });
+
+        await expectViolations(myObject, V.notEmpty(), defaultViolations.notEmpty(ROOT, myObject));
+      });
+
+      test('validates corner case prototyped objects having an inherited property length > 0', async () => {
+        const myObject = Object.create({
+          length: 5,
+        });
+
+        await expectViolations(myObject, V.notEmpty(), defaultViolations.notEmpty(ROOT, myObject));
+      });
+    });
   });
 });
 

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -22,7 +22,8 @@ export interface ValidatorOptions {
 }
 
 export class ValidationContext {
-  constructor(public readonly options: ValidatorOptions) {}
+  constructor(public readonly options: ValidatorOptions) {
+  }
 
   private readonly objects = new Map<any, any>();
 
@@ -38,18 +39,23 @@ export class ValidationContext {
     }
     return new ValidationResult(violations);
   }
+
   success(value: any) {
     return new ValidationResult(undefined, value);
   }
+
   failurePromise(violation: Violation | Violation[], value: any) {
     return this.promise(this.failure(violation, value));
   }
+
   successPromise(value: any) {
     return this.promise(this.success(value));
   }
+
   promise<T>(result: ValidationResult) {
     return new SyncPromise(result);
   }
+
   registerObject(value: any, path: Path, convertedValue: any): undefined | ValidationResult {
     if (this.objects.has(value)) {
       if (this.options.allowCycles) {
@@ -60,6 +66,7 @@ export class ValidationContext {
     this.objects.set(value, convertedValue);
     return undefined;
   }
+
   private ignoreViolation(violation: Violation) {
     return (
       (this.options.ignoreUnknownEnumValues && violation.type === ValidatorType.EnumMismatch) ||
@@ -69,7 +76,9 @@ export class ValidationContext {
 }
 
 export class SyncPromise<T> implements PromiseLike<T> {
-  constructor(private readonly value: T) {}
+  constructor(private readonly value: T) {
+  }
+
   then<TResult1 = T, TResult2 = never>(
     onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null,
@@ -160,7 +169,8 @@ export class ValidationError extends Error {
 }
 
 export class Violation {
-  constructor(public readonly path: Path, public readonly type: string, public readonly invalidValue?: any) {}
+  constructor(public readonly path: Path, public readonly type: string, public readonly invalidValue?: any) {
+  }
 }
 
 export class TypeMismatch extends Violation {
@@ -306,7 +316,7 @@ export const defaultViolations = {
   max: (max: number, inclusive: boolean, invalidValue: any, path: Path = ROOT) => new MaxViolation(path, max, inclusive, invalidValue),
   size: (min: number, max: number, path: Path = ROOT) => new SizeViolation(path, min, max),
   notNull: (path: Path = ROOT) => new Violation(path, ValidatorType.NotNull),
-  notEmpty: (path: Path = ROOT) => new Violation(path, ValidatorType.NotEmpty),
+  notEmpty: (path: Path = ROOT, invalidValue?: any) => new Violation(path, ValidatorType.NotEmpty),
   notBlank: (path: Path = ROOT) => new Violation(path, ValidatorType.NotBlank),
   oneOf: (matches: number, path: Path = ROOT) => new OneOfMismatch(path, matches),
   pattern: (pattern: RegExp, invalidValue: any, path: Path = ROOT) => new PatternViolation(path, '' + pattern, invalidValue),
@@ -605,6 +615,7 @@ export class ObjectNormalizer extends Validator {
     super();
     Object.freeze(this);
   }
+
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
     if (value === undefined) {
       return ctx.successPromise(undefined);
@@ -676,6 +687,7 @@ export class ArrayNormalizer extends ArrayValidator {
   constructor(itemsValidator: Validator) {
     super(itemsValidator);
   }
+
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
     if (value === undefined) {
       return super.validatePath([], path, ctx);
@@ -777,6 +789,7 @@ export class AnyOfValidator extends Validator {
     Object.freeze(this.validators);
     Object.freeze(this);
   }
+
   async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<ValidationResult> {
     const passes: ValidationResult[] = [];
     const failures: Violation[] = [];
@@ -874,6 +887,7 @@ export class WhenGroupValidator extends Validator {
     return new WhenGroupValidator(this.whenGroups, maybeAllOfValidator(allOf));
   }
 }
+
 export class WhenGroup {
   public readonly group: string;
 
@@ -891,6 +905,7 @@ export class MapValidator extends Validator {
     super();
     Object.freeze(this);
   }
+
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
     if (isNullOrUndefined(value)) {
       return ctx.failurePromise(defaultViolations.notNull(path), value);
@@ -940,6 +955,7 @@ export class MapNormalizer extends MapValidator {
   constructor(keys: Validator, values: Validator) {
     super(keys, values, true);
   }
+
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
     if (value instanceof Map) {
       return super.validatePath(value, path, ctx);
@@ -972,6 +988,7 @@ export class JsonMap<K, V> extends Map<K, V> {
   constructor(params?: any) {
     super(params);
   }
+
   toJSON() {
     return [...this.entries()];
   }
@@ -1033,10 +1050,19 @@ export class IsNullOrUndefinedValidator extends Validator {
 
 export class NotEmptyValidator extends Validator {
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
-    return !isNullOrUndefined(value) && isNumber(value.length) && value.length > 0
-      ? ctx.successPromise(value)
-      : ctx.failurePromise(defaultViolations.notEmpty(path), value);
+    if (isNullOrUndefined(value) || (isObject(value) && !Object.keys(value).length) || (hasNumericLength(value) && !value.length)) {
+      return ctx.failurePromise(defaultViolations.notEmpty(path, value), value);
+    }
+    return ctx.successPromise(value);
   }
+}
+
+function isObject(value: any) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasNumericLength(value: any) {
+  return (Array.isArray(value) || typeof value === 'string') && typeof value.length === 'number';
 }
 
 export class SizeValidator extends Validator {
@@ -1147,6 +1173,7 @@ export class NumberValidator extends Validator {
     }
     return this.validateFormat(value, path, ctx);
   }
+
   protected validateFormat(value: any, path: Path, ctx: ValidationContext) {
     switch (this.format) {
       case NumberFormat.integer:
@@ -1273,6 +1300,7 @@ export class HasValueValidator extends Validator {
     super();
     Object.freeze(this);
   }
+
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
     if (deepEqual(value, this.expectedValue)) {
       return ctx.successPromise(value);
@@ -1393,6 +1421,7 @@ export class PatternNormalizer extends PatternValidator {
   constructor(pattern: string | RegExp, flags?: string) {
     super(pattern, flags);
   }
+
   validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> {
     if (isNullOrUndefined(value)) {
       return ctx.failurePromise(defaultViolations.notNull(path), value);


### PR DESCRIPTION
## Description of Change
In this PR, we have enhanced the capabilities of our existing `notEmpty` validator within our validation framework. This update broadens the scope of the validator to include checks for empty values in arrays, objects, strings, and to detect undefined or null values.

The purpose of this enhancement is to fortify our input validation processes by ensuring that a variety of input types are not just present but also hold meaningful content. The updated `notEmpty` validator is now more versatile, able to handle different types of inputs with the same stringent criteria.

## Use Case Implementation

An example of where this enhanced validator is now used is in the user password validation process. The `userValidator` utilizes the updated `notEmpty` validator to confirm that the password field is filled with valid and substantial content, reinforcing the security measures in our system.

### Code Example

```javascript
const userValidator = V.notEmpty().next(V.object({
  properties: {
    password1: V.string().next(V.pattern(/[A-Z]/), V.pattern(/[a-z]/), V.pattern(/[0-9]/), V.size(8, 32)),
    password2: V.string(),
  },
}));
const result = await userValidator.validate({});
console.log(result.getViolations());
```
console output:
```
[
  Violation {
    path: Path { path: [] },
    type: 'NotEmpty',
    invalidValue: undefined
  }
]
```

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context
We have been working on an important feature in our team that requires this validator or similar to be implemented. For example, when all properties of an object are optional, but at least one of them is required and we don't know which one is, it is important to have such validation option in place, and this validator solves the problem.

## How Has This Been Tested?
Added a bunch of tests in the code to check that this works as expected.

## Screenshots (if appropriate):