### PR TITLE
feat: validation result as unknown instead of any

### DIFF
--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -122,11 +122,11 @@ export interface WarnLogger {
 }
 
 export class ValidationResult {
-  private value?: any;
+  private value?: unknown;
 
   private violations?: Violation[];
 
-  constructor(violations?: Violation[], value?: any) {
+  constructor(violations?: Violation[], value?: unknown) {
     this.violations = violations;
     this.value = value;
     Object.freeze(this.violations);
@@ -140,7 +140,7 @@ export class ValidationResult {
     return !this.isSuccess();
   }
 
-  getValue(): any {
+  getValue(): unknown {
     if (!this.isSuccess()) {
       throw new ValidationError(this.getViolations());
     }
@@ -778,7 +778,7 @@ export class AnyOfValidator extends Validator {
     Object.freeze(this);
   }
   async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<ValidationResult> {
-    const passes: ValidationResult[] = [];
+    const passes: unknown[] = [];
     const failures: Violation[] = [];
 
     for (let i = 0; i < this.validators.length; i++) {


### PR DESCRIPTION
"Any" can be assigned to any type, while unknown forces the user to cast the value of the ValidationResult to a proper type (or any) before using it. This exposes errors better than any (as shown by this PR).