### PR TITLE
feat: type guards to verify validator and existing type equality

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -247,7 +247,18 @@ Since inferred types tend to get quite long and hard to read, you can also combi
 
 ### Typeguards (Work in Proggress)
 
-When using custom interfaces it's good to verify that the validator is in sync with the interface:
+When using custom interfaces it's good to verify that the validator is in sync with the interface. The 
+challenge is that TypeScript generic `extends` only verifies type compatibility, optional
+properties do not count unless they are of conflicting type. For type-validator compatibility
+we need to also consider optional properties and nested structure. For this there is two helper
+types:
+
+1. `ComparableType<T>` converts all optional properties to mandatory `Optional<T>` recursively.
+2. `VerifyEqualTypes<A, B>` verifies that `A extends B` and `B extends A`.  
+
+Last hack that is needed, is ignoring unused type error about the `VerifyEqualTypes`. There's at least two
+ways for that:
+
 ```typescript
 interface MyInterface{
   //...
@@ -258,7 +269,15 @@ const myInterfaceValidator = V.objectType()
   })
   .build();
 
+// 1) use VerifyEqualTypes to make "VerifiedType" and use that
 type MyVerifiedInterface = VerifyEqualTypes<ComparableType<VType<typeof myInterfaceValidator>>, ComparableType<MyInterface>> extends true ? MyInterface : never
+
+// 2) Split VerifyEqualTypes on two or more lines and ignore the unused variable error
+// @ts-ignore
+type verify = VerifyEqualTypes<
+  ComparableType<VType<typeof myInterfaceValidator>>, 
+  ComparableType<MyInterface>
+>
 ```
 
 ## Combining Validators

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -447,6 +447,14 @@ describe('objects', () => {
         >;
       });
     });
+
+    test('next allows conversion to string', () => {
+      const validator = V.objectType()
+        .properties({ value: V.string() })
+        .next(V.map( value => JSON.stringify(value) ))
+        .build();
+      assertType<EqualTypes<VType<typeof validator>, string>>(true);
+    });
   });
 
   test('input is not modified', async () => {

--- a/packages/core/src/V.ts
+++ b/packages/core/src/V.ts
@@ -196,7 +196,7 @@ export const V = {
   size: <T extends { length: number }>(min: number, max: number) => new SizeValidator<T>(min, max),
 
   properties: <Key extends keyof any, Value>(keys: Validator<Key>, values: Validator<Value>) => 
-    new ObjectValidator<Record<Key, Value>>({ additionalProperties: { keys, values } }),
+    new ObjectValidator<{ [key in Key]?: Value }>({ additionalProperties: { keys, values } }),
 
   allOf: AllOfConstructor,
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from './V.js';
 export * from './validators.js';
 export * from './objectValidator.js';
 export * from './objectValidatorBuilder.js';
+export * from './typing.js';

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -31,6 +31,8 @@ export interface PropertyFilter {
   (key: string): boolean;
 }
 
+export type VInheritableType<V extends ObjectValidator<any, any>> = V extends ObjectValidator<any, infer Out> ? Out : unknown;
+
 export interface ObjectModel<LocalType = unknown, InheritableType = unknown> {
   /**
    * Inherit all non-local rules from parent validators. 
@@ -61,7 +63,7 @@ export interface ObjectModel<LocalType = unknown, InheritableType = unknown> {
   readonly localNext?: Validator | Validator[];
 }
 
-export class ObjectValidator<LocalType = unknown, InheritableType = unknown> extends Validator<LocalType, unknown> {
+export class ObjectValidator<LocalType = unknown, InheritableType = LocalType> extends Validator<LocalType, unknown> {
   public readonly properties: Properties;
 
   public readonly localProperties: Properties;
@@ -99,7 +101,10 @@ export class ObjectValidator<LocalType = unknown, InheritableType = unknown> ext
     this.additionalProperties = additionalProperties.concat(getMapEntryValidators(model.additionalProperties));
     this.properties = mergeProperties(getPropertyValidators(model.properties), properties);
     this.localProperties = getPropertyValidators(model.localProperties);
-    this.nextValidator = nextValidators.length > 0 ? maybeCompositionOf(...(nextValidators as CompositionParameters)) : undefined;
+    const next = nextValidators.length > 0 ? maybeCompositionOf(...(nextValidators as CompositionParameters)) : undefined;
+    if (next) {
+      this.nextValidator = next;
+    }
     if (model.localNext) {
       if (!Array.isArray(model.localNext)) {
         this.localNextValidator = model.localNext;

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -38,18 +38,18 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
     this._additionalProperties.push({ keys, values });
     return this as ObjectValidatorBuilder<Props & { [key in K]?: V }, Next, LocalProps, LocalNext>;
   }
-  next<NextOut>(validator: Validator<NextOut, Next extends object ? Next : Props>) {
+  next<NextOut extends {}>(validator: Validator<NextOut, Next extends {} ? Next : Props>) {
     this._next?.push(validator);
     return this as unknown as ObjectValidatorBuilder<Props, NextOut, LocalProps, LocalNext>;
   }
-  localNext<NextOut>(validator: Validator<NextOut, LocalNext extends object ? LocalNext : Next extends object ? Next : Props & LocalProps>) {
+  localNext<NextOut extends {}>(validator: Validator<NextOut, LocalNext extends {} ? LocalNext : Next extends {} ? Next : Props & LocalProps>) {
     this._localNext?.push(validator);
     return this as unknown as ObjectValidatorBuilder<Props, Next, LocalProps, NextOut>;
   }
   build() {
     return new ObjectValidator<
-        (Next extends object ? Next : Props) & (LocalNext extends object ? LocalNext : LocalProps), 
-        (Next extends object ? Next : Props)
+        (Next extends {} ? Next : Props) & (LocalNext extends {} ? LocalNext : LocalProps), 
+        (Next extends {} ? Next : Props)
       >({
       extends: this._extends,
       properties: this._properties,

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -1,16 +1,7 @@
 import { V } from "./V.js";
 import { Validator } from "./validators.js";
 import { MapEntryModel, ObjectValidator, PropertyModel, strictUnknownPropertyValidator } from "./objectValidator.js";
-
-type KeysOfType<T, SelectedType> = {
-  [key in keyof T]: SelectedType extends T[key] ? key : never;
-}[keyof T];
-
-type OptionalProperties<T> = Partial<Pick<T, KeysOfType<T, undefined>>>;
-
-type RequiredProperties<T> = Omit<T, KeysOfType<T, undefined>>;
-
-type UndefinedAsOptionalProperties<T> = RequiredProperties<T> & OptionalProperties<T>;
+import { UndefinedAsOptionalProperties } from "./typing.js";
 
 export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
   private _extends: ObjectValidator[] = [];

--- a/packages/core/src/schema.spec.ts
+++ b/packages/core/src/schema.spec.ts
@@ -1,9 +1,10 @@
 import { describe, test, expect } from 'vitest'
 import { SchemaValidator, DiscriminatorViolation } from './schema.js';
 import { V } from './V.js';
-import { defaultViolations, TypeMismatch, ObjectValidator, HasValueViolation, Violation } from './validators.js';
+import { defaultViolations, TypeMismatch, HasValueViolation, Violation } from './validators.js';
 import { expectViolations, expectValid } from './testUtil.spec.js';
 import { Path } from '@finnair/path';
+import { ObjectValidator } from './objectValidator.js';
 
 const ROOT = Path.ROOT,
   property = Path.property;

--- a/packages/core/src/typing.ts
+++ b/packages/core/src/typing.ts
@@ -1,0 +1,32 @@
+
+type KeysOfType<T, SelectedType> = {
+  [key in keyof T]: SelectedType extends T[key] ? key : never;
+}[keyof T];
+
+type OptionalProperties<T> = Partial<Pick<T, KeysOfType<T, undefined>>>;
+
+type RequiredProperties<T> = Omit<T, KeysOfType<T, undefined>>;
+
+export type UndefinedAsOptionalProperties<T> = RequiredProperties<T> & OptionalProperties<T>;
+
+type Optional<T> = { type: Exclude<T, undefined> };
+
+type ComparableOptional<T> = T extends object
+  ? { [K in keyof T]-?:  Optional<ComparableType<T[K]>> }
+  : T;
+
+type ComparableRequired<T> = T extends object
+  ? { [K in keyof T]:  ComparableType<T[K]> }
+  : T;
+
+export type ComparableType<T> = T extends object 
+  ? ComparableRequired<RequiredProperties<T>> & ComparableOptional<OptionalProperties<T>>
+  : T;
+
+/**
+ * Verify mutual extensibility. When using this with both types wrapped in`ComparableType`, you get 
+ * proper errors about all differences in `Inferred` and `Custom` types. 
+ */
+export type EqualTypes<Inferred extends Custom, Custom extends T, T = Inferred> = true;
+
+export const assertType = <Type>(_: Type): void => void 0;


### PR DESCRIPTION
Verify type-equality of a validator and existing type/interface with `VerifyEqualType` and `ComparableType` helpers:
```
assertType<VerifyEqualTypes<
  ComparableType<VType<typeof myInterfaceValidator>>, 
  ComparableType<MyInterface>
>>(true)
```
