### PR TITLE
feat: `V.oneOf`reports all results in case of error + fixed cycle detection

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -550,8 +550,8 @@ Another option is to use [`V.schema`](#schema).
 By default `V` returns an error if same object is referenced multiple times in the input data structure.
 While plain data cannot contain duplicates, as they require references, `V` allows these and even
 cyclic data by setting `ValidatorOptions.allowCycles = true`. The converted object returned by successful 
-validation retains identical reference structure compared to the original. Note, however, that cycles 
-can only be connected in the converted result if the same validation rule is used on both ends. If different
+validation retains identical reference structure compared to the original. _Note, however, that cycles 
+can only be connected in the converted result if the same validation rule is used on both ends._ If different
 ObjectValidator rule is used, then the separate branches will result in a different copy of the
 converted object. In such case, it's better to use [Pure validation](#pure-validation).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -227,7 +227,7 @@ type UserRegistration = VType<typeof UserRegistrationValidator>;
 - TypeScript native implementation
 - Supports type inference that can be mixed with better readable custom types/interfaces
 
-## Pure Validation?
+## <a name="pure-validation">Pure Validation</a>
 
 As a matter of principle, `V` doesn't modify the value being validated. All conversions and normalizations return a new object or array. For pure validation,
 
@@ -549,8 +549,11 @@ Another option is to use [`V.schema`](#schema).
 
 By default `V` returns an error if same object is referenced multiple times in the input data structure.
 While plain data cannot contain duplicates, as they require references, `V` allows these and even
-cyclic data by setting `ValidatorOptions.allowCycles = true`. The converted object returned by
-successful validation retains identical reference structure compared to the original.
+cyclic data by setting `ValidatorOptions.allowCycles = true`. The converted object returned by successful 
+validation retains identical reference structure compared to the original. Note, however, that cycles 
+can only be connected in the converted result if the same validation rule is used on both ends. If different
+ObjectValidator rule is used, then the separate branches will result in a different copy of the
+converted object. In such case, it's better to use [Pure validation](#pure-validation).
 
 ## Map
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -551,9 +551,9 @@ By default `V` returns an error if same object is referenced multiple times in t
 While plain data cannot contain duplicates, as they require references, `V` allows these and even
 cyclic data by setting `ValidatorOptions.allowCycles = true`. The converted object returned by successful 
 validation retains identical reference structure compared to the original. _Note, however, that cycles 
-can only be connected in the converted result if the same validation rule is used on both ends._ If different
-ObjectValidator rule is used, then the separate branches will result in a different copy of the
-converted object. In such case, it's better to use [Pure validation](#pure-validation).
+can only be connected in the converted result if the same validation rule is used on both ends._ 
+If different ObjectValidator rule is used, then the separate branches will result in a different copy of
+the converted object. In such case, it's better to use [Pure validation](#pure-validation).
 
 ## Map
 

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -139,7 +139,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType> e
       convertedObject: {} as LocalType,
       violations: [],
     };
-    const cycleResult = ctx.registerObject<LocalType>(value, path, context.convertedObject);
+    const cycleResult = ctx.registerObject<LocalType>(value, path, this, context.convertedObject);
     if (cycleResult) {
       return cycleResult;
     }

--- a/packages/path/src/Path.spec.ts
+++ b/packages/path/src/Path.spec.ts
@@ -119,6 +119,10 @@ describe('path', () => {
     expect(path).toEqual(Path.of('parent', 'nested', 0));
   });
 
+  test('child', () => {
+    expect(Path.of('foo').child(1).child('bar')).toEqual(Path.of('foo', 1, 'bar'));
+  });
+
   describe('equals', () => {
     test('equal path', () => {
       expect(Path.of('foo', 0).equals(Path.of('foo', 0))).toBe(true);

--- a/packages/path/src/Path.spec.ts
+++ b/packages/path/src/Path.spec.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest'
 import { Path, PathComponent } from './Path.js';
 import { PathMatcher } from './PathMatcher.js';
 import { AnyProperty, AnyIndex } from './matchers.js';
+import path from 'path';
 
 describe('path', () => {
   test('toJSON', () => expect(Path.property('s p a c e s').index(5).property('regular').toJSON()).toEqual('$["s p a c e s"][5].regular'));
@@ -116,6 +117,24 @@ describe('path', () => {
     expect(parent).toBeUndefined();
     // original is not modified
     expect(path).toEqual(Path.of('parent', 'nested', 0));
+  });
+
+  describe('equals', () => {
+    test('equal path', () => {
+      expect(Path.of('foo', 0).equals(Path.of('foo', 0))).toBe(true);
+    });
+    test('non equal path', () => {
+      expect(Path.of('foo', 0).equals(Path.of('foo', 1))).toBe(false);
+    });
+    test('string and number indexes are equal', () => {
+      expect(Path.of('foo', 0).equals(Path.of('foo', "0"))).toBe(true);
+    });
+    test('shorter path', () => {
+      expect(Path.of('foo', 'bar').equals(Path.of('foo'))).toBe(false);
+    })
+    test('longer path', () => {
+      expect(Path.of('foo').equals(Path.of('foo', 'bar'))).toBe(false);
+    })
   });
 
   describe('validate components', () => {

--- a/packages/path/src/Path.ts
+++ b/packages/path/src/Path.ts
@@ -43,6 +43,21 @@ export class Path {
     return this.path.reduce((pathString: string, component: PathComponent) => pathString + Path.componentToString(component), '$');
   }
 
+  equals(other: any) {
+    if (other instanceof Path) {
+      const otherLength = other.length;
+      if (otherLength === this.length) {
+        for (let i = 0; i < otherLength; i++) {
+          if (other.componentAt(i) != this.componentAt(i)) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
   get length(): number {
     return this.path.length;
   }

--- a/packages/path/src/Path.ts
+++ b/packages/path/src/Path.ts
@@ -23,6 +23,13 @@ export class Path {
     return new Path(this.path.concat(property));
   }
 
+  child(key: number | string): Path {
+    if (typeof key === 'number') {
+      return this.index(key);
+    }
+    return this.property(key);
+  }
+
   connectTo(newRootPath: Path) {
     return new Path(newRootPath.path.concat(this.path));
   }


### PR DESCRIPTION
* fix: cycle detection so that e.g. `V.oneOf` can handle multiple ObjectValidator alternatives.
* feat: `V.oneOf` reports all ValidationResults in case of error
* feat: Path.equals method to compare paths
* feat: Path.child method to create a new index or property subpath