### PR TITLE
feat!: optimized projection and jsonClone function

### DIFF
--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -25,7 +25,7 @@ import {
 } from './validators.js';
 import { ObjectValidator, ObjectModel, VInheritableType } from './objectValidator.js';
 import { V } from './V.js';
-import { Path } from '@finnair/path';
+import { jsonClone, Path } from '@finnair/path';
 import { expectUndefined, expectValid, expectViolations, verifyValid } from './testUtil.spec.js';
 import { fail } from 'assert';
 import { EqualTypes, ComparableType, assertType } from './typing.js';
@@ -189,7 +189,7 @@ describe('strings', () => {
     test('convert to string', () => expectValid(123, V.toString().next(V.pattern('^[0-9]+$')), '123'));
 
     test('violation toJSON', () => {
-      expect(JSON.parse(JSON.stringify(defaultViolations.pattern(/[A-Z]+/i, '123')))).toEqual({
+      expect(jsonClone(defaultViolations.pattern(/[A-Z]+/i, '123'))).toEqual({
         path: '$',
         pattern: '/[A-Z]+/i',
         type: 'Pattern',
@@ -1873,7 +1873,7 @@ describe('Set', () => {
     const set1 = (await validator.validate(new Set(setArray))).getValue();
     expect(set1).toBeInstanceOf(JsonSet);
 
-    const parsedArray = JSON.parse(JSON.stringify(set1));
+    const parsedArray = jsonClone(set1);
     expect(parsedArray).toEqual(setArray);
   });
 

--- a/packages/path/README.md
+++ b/packages/path/README.md
@@ -22,6 +22,13 @@ Or [`npm`](https://www.npmjs.com/):
 npm install @finnair/path
 ```
 
+## New in Version 9
+
+* BREAKING CHANGE: Projection will always return JSON-compliant clone of the input, not the input itself even if there are no include/exclude/always
+* Projection supports also "always" paths to specify which paths should be always included regardless of includes and excludes
+* Projection supports a replacer function as specified by `JSON.stringify`
+* New `jsonClone` method to create a JSON compliant clone of the input 
+
 ## Use Case Examples
 
 ### Validation 
@@ -34,19 +41,32 @@ Analyze changes and trigger logic based on what has changed (see [`diff`](../dif
 
 ### Include/Exclude Projection
 
-While GraphQL is all about projections, something similar can also be implemented in a REST API with include/exclude parameters. `Projection` and `parsePathMatcher` function provides means to process results safely based on such a user input. This is, of course, very simplified projection compared to what GraphQL has to offer, but it's also... well, simpler.
+While GraphQL is all about projections, something similar can also be implemented in a REST API with include, exclude and always parameters. `Projection` and `parsePathMatcher` function provides means to process results safely based on such a user input. This is, of course, very simplified projection compared to what GraphQL has to offer, but it's also... well, simpler.
 
 Projection can also be used to optimize fetching expensive relations as it also supports matching Paths and not just mapping actual values:
 
 ```typescript
 const resource = fetchResult(request);
-const projection = Projection.of(parseIncludes(request), parseExcludes(request));
+const projection = Projection.of(
+  parseIncludes(request), 
+  parseExcludes(request), 
+  [PathMatcher.of('id')], // id is always included
+  replacer // optional JSON.stringify replacer function
+);
 const result = {
   ...resource,
-  veryExpensiveRelation: projection.match(Path.of('veryExpensiveRelation')) ? fetchVeryExpensiveRelation(resource) : undefined,
+  veryExpensiveRelation: projection.match(Path.of('veryExpensiveRelation')) 
+    ? fetchVeryExpensiveRelation(resource) 
+    : undefined,
 };
 return projection.map(result);
 ```
+
+NOTE: Projection cannot be used to access anything that is not visible to JSON. Input is always converted to JSON compliant model before any processing. 
+
+### JSON Clone
+
+As safe include/exclude requires JSON conversion, this library also contains a handy `jsonClone` method that can be used to e.g. normalize input. 
 
 ## Using Path
 

--- a/packages/path/src/Projection.spec.ts
+++ b/packages/path/src/Projection.spec.ts
@@ -35,7 +35,11 @@ describe('project', () => {
     Object.freeze(obj.array[1]);
     Object.freeze(obj.array[2]);
 
-    test('Returns the original object without includes and excludes', () => expect(projection(undefined, [])(obj)).toBe(obj));
+    test('Returns the a new object without includes and excludes', () => {
+      const result = projection(undefined, [])(obj);
+      expect(result).not.toBe(obj);
+      expect(result).toEqual(obj);
+    });
 
     test('Returns a clone with include', () => expect(projection([PathMatcher.of(AnyProperty)], undefined)(obj)).not.toBe(obj));
 

--- a/packages/path/src/Projection.spec.ts
+++ b/packages/path/src/Projection.spec.ts
@@ -129,6 +129,16 @@ describe('project', () => {
       expect(projection([PathMatcher.of('non-existing-property')], [PathMatcher.of(AnyProperty)], [PathMatcher.of('id')])(obj))
         .toEqual({ id: 'id' })
     );
+
+    describe('projection map input should be non-null object', () => {
+      test('toJSON => null', () => {
+        expect(() => projection()({ toJSON() { return null; } })).toThrow();
+      });
+  
+      test('replacer => string', () => {
+        expect(() => projection(undefined, undefined, undefined, () => 'string')({})).toThrow();
+      });
+    });
   });
 
   describe('match', () => {

--- a/packages/path/src/index.ts
+++ b/packages/path/src/index.ts
@@ -2,3 +2,4 @@ export { Path, PathComponent } from './Path.js';
 export * from './PathMatcher.js';
 export * from './matchers.js';
 export * from './Projection.js';
+export * from './jsonClone.js';

--- a/packages/path/src/jsonClone.spec.ts
+++ b/packages/path/src/jsonClone.spec.ts
@@ -1,0 +1,112 @@
+import { jsonClone } from './jsonClone';
+import { describe, test, expect } from 'vitest'
+
+class MyClass {
+  constructor(public visibleValue: any, public hiddenValue: any) {}
+  toJSON() {
+    return {
+      visibleValue: this.visibleValue,
+      date: new Date(2026, 3, 12, 1, 2, 3, 4),
+      bigint: 123n,
+    };
+  }
+}
+
+const ignoredSymbol = Symbol('ignoredSymbol');
+
+describe('jsonClone', () => {
+  const funkyArray: any[] = [
+    "string",
+    1,
+    ignoredSymbol,
+    true,
+    JSON.stringify,
+    new Date(2027, 4, 12, 1, 2, 3, 4)
+  ];
+  (<any>funkyArray).ignoredProperty = 'ignoredProperty';
+
+  const funkyObject = {
+    string: "string",
+    1: 1,
+    boolean: true,
+    object: {
+      plain: "object",
+    },
+    array: funkyArray,
+    myClass: new MyClass('visibleValue', 'hiddenValue'),
+    ignoredFunction() {
+      return 'ignoredFunction';
+    },
+    bigint: 456n,
+    [ignoredSymbol]: 'ignoredSymbol',
+    toJSON(key: string) {
+      if (key === '') {
+        return {
+          ...this
+        }
+      } else {
+        return null;
+      }
+    }
+  };
+
+  test('object with toJSON and replacer function', () => {
+    const replacer = (key: string, value: any) => {
+      if (typeof value === 'bigint') {
+        return value.toString();
+      }
+      return value;
+    };
+
+    const clone = jsonClone(funkyObject, replacer);
+
+    expect(clone).toStrictEqual({
+      string: "string",
+      1: 1,
+      boolean: true,
+      object: {
+        plain: "object",
+      },
+      array: [
+        "string",
+        1,
+        null,
+        true,
+        null,
+        '2027-05-12T01:02:03.004Z',
+      ],
+      myClass: {
+        visibleValue: 'visibleValue',
+        date: '2026-04-12T01:02:03.004Z',
+        bigint: '123',
+      },
+      bigint: '456',
+    })
+    expect(clone).toStrictEqual(JSON.parse(JSON.stringify(funkyObject, replacer)));
+  });
+
+  test('array replacer', () => {
+    const replacer = ['myClass', 'array', 'visibleValue'];
+
+    const clone = jsonClone(funkyObject, replacer);
+    
+    expect(clone).toStrictEqual({
+      array: [
+        "string",
+        1,
+        null,
+        true,
+        null,
+        '2027-05-12T01:02:03.004Z',
+      ],
+      myClass: {
+        visibleValue: 'visibleValue',
+      },
+    })
+    expect(clone).toStrictEqual(JSON.parse(JSON.stringify(funkyObject, replacer)));
+  });
+
+  test('bigint throws an exception', () => {
+    expect(() => jsonClone(1n)).toThrow("BigInt value can't be serialized in JSON");
+  });
+});

--- a/packages/path/src/jsonClone.spec.ts
+++ b/packages/path/src/jsonClone.spec.ts
@@ -109,4 +109,28 @@ describe('jsonClone', () => {
   test('bigint throws an exception', () => {
     expect(() => jsonClone(1n)).toThrow("BigInt value can't be serialized in JSON");
   });
+
+  test('jsonClone of undefined is undefined', () => {
+    expect(jsonClone(undefined)).toBeUndefined();
+  });
+
+  test('jsonClone of null is null', () => {
+    expect(jsonClone(null)).toBe(null);
+  });
+
+  test('jsonClone of function is undefined', () => {
+    expect(jsonClone(JSON.stringify)).toBeUndefined();
+  });
+
+  test('jsonClone of symbol is undefined', () => {
+    expect(jsonClone(ignoredSymbol)).toBeUndefined();
+  });
+
+  test('jsonClone of number is number', () => {
+    expect(jsonClone(123)).toBe(123);
+  });
+
+  test('jsonClone of boolean is boolean', () => {
+    expect(jsonClone(true)).toBe(true);
+  });
 });

--- a/packages/path/src/jsonClone.ts
+++ b/packages/path/src/jsonClone.ts
@@ -1,24 +1,19 @@
 export type JsonReplacer = ((this: any, key: string, value: any) => any) | (number | string)[] | null;
 
-export function jsonClone(input: any, replacer?: JsonReplacer) {
-  return _jsonClone('', { '': input }, replacer);
+export type JsonValue = string | boolean | number | JsonValue[] | null | JsonObject;
+
+export type JsonObject = {
+  [key: string]: JsonValue;
 }
 
-function _replaceValue(key: string, holder: any, replacer?: JsonReplacer) {
-  let value = holder[key];
-  if (typeof value?.toJSON === 'function') {
-    value = value.toJSON(key);
-  }
-  if (typeof replacer === 'function') {
-    value = replacer.call(holder, key, value);
-  }
-  return value;
+export function jsonClone(input: any, replacer?: JsonReplacer): JsonValue {
+  return _jsonClone('', { '': input }, replacer);
 }
 
 function _jsonClone(key: string, holder: any, replacer?: JsonReplacer) {
   const value = _replaceValue(key, holder, replacer);
   if (value && typeof value === 'object') {
-    let clone: any;
+    let clone: JsonValue;
     if (Array.isArray(value)) {
       clone = [];
       for (let i=0; i < value.length; i++) {
@@ -60,4 +55,15 @@ function _jsonClone(key: string, holder: any, replacer?: JsonReplacer) {
         return value;
     }
   }
+}
+
+function _replaceValue(key: string, holder: any, replacer?: JsonReplacer) {
+  let value = holder[key];
+  if (typeof value?.toJSON === 'function') {
+    value = value.toJSON(key);
+  }
+  if (typeof replacer === 'function') {
+    value = replacer.call(holder, key, value);
+  }
+  return value;
 }

--- a/packages/path/src/jsonClone.ts
+++ b/packages/path/src/jsonClone.ts
@@ -1,0 +1,58 @@
+export type JsonReplacer = ((this: any, key: string, value: any) => any) | (number | string)[] | null;
+
+export function jsonClone(input: any, replacer?: JsonReplacer) {
+  return _jsonClone('', { '': input }, replacer);
+}
+
+function _jsonClone(key: string, holder: any, replacer?: JsonReplacer) {
+  let value = holder[key];
+  if (typeof value?.toJSON === 'function') {
+    value = value.toJSON(key);
+  }
+  if (typeof replacer === 'function') {
+    value = replacer.call(holder, key, value);
+  }
+  if (value && typeof value === 'object') {
+    let clone: any;
+    if (Array.isArray(value)) {
+      clone = [];
+      for (let i=0; i < value.length; i++) {
+        clone[i] = _jsonClone(i.toString(), value, replacer) ?? null;
+      }
+    } else {
+      clone = {};
+      if (Array.isArray(replacer)) {
+        const len = replacer.length;
+        for (let i=0; i < len; i++) {
+          const nestedKey = replacer[i].toString();
+          const keyValue = _jsonClone(nestedKey, value, replacer);
+          // undefined is not included in the result
+          if (keyValue !== undefined) {
+            clone[nestedKey] = keyValue;
+          }
+        }
+      } else {
+        for (const nestedKey in value) {
+          const keyValue = _jsonClone(nestedKey, value, replacer);
+          // undefined is not included in the result
+          if (keyValue !== undefined) {
+            clone[nestedKey] = keyValue;
+          }
+        }
+      }
+    }
+    return clone;
+  } else {
+    switch (typeof value) {
+      // ignore function and symbol
+      case 'function':
+      case 'symbol':
+        return undefined;
+      // BigInt is not supported by JSON.stringify
+      case 'bigint': 
+        throw new TypeError("BigInt value can't be serialized in JSON");
+      default: 
+        return value;
+    }
+  }
+}

--- a/packages/path/src/jsonClone.ts
+++ b/packages/path/src/jsonClone.ts
@@ -4,7 +4,7 @@ export function jsonClone(input: any, replacer?: JsonReplacer) {
   return _jsonClone('', { '': input }, replacer);
 }
 
-function _jsonClone(key: string, holder: any, replacer?: JsonReplacer) {
+function _replaceValue(key: string, holder: any, replacer?: JsonReplacer) {
   let value = holder[key];
   if (typeof value?.toJSON === 'function') {
     value = value.toJSON(key);
@@ -12,6 +12,11 @@ function _jsonClone(key: string, holder: any, replacer?: JsonReplacer) {
   if (typeof replacer === 'function') {
     value = replacer.call(holder, key, value);
   }
+  return value;
+}
+
+function _jsonClone(key: string, holder: any, replacer?: JsonReplacer) {
+  const value = _replaceValue(key, holder, replacer);
   if (value && typeof value === 'object') {
     let clone: any;
     if (Array.isArray(value)) {


### PR DESCRIPTION
Calling `jsonClone(value)` will result in same as `JSON.parse(JSON.stringify(value))` but without actual serialization.

There is a minor breaking change in this as projection will always return a "JSON clone" of the input object, instead of input directly in a case where there are no includes/excludes.

BREAKING CHANGE