### PR TITLE
fix: type-checking optional/undefined properties

### DIFF
--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -28,7 +28,7 @@ import { V } from './V.js';
 import { jsonClone, Path } from '@finnair/path';
 import { expectUndefined, expectValid, expectViolations, verifyValid } from './testUtil.spec.js';
 import { fail } from 'assert';
-import { EqualTypes, ComparableType, assertType } from './typing.js';
+import { EqualTypes, ComparableType, assertType, OptionalKeys } from './typing.js';
 
 const ROOT = Path.ROOT,
   index = Path.index,
@@ -304,6 +304,10 @@ describe('objects', () => {
   });
 
   describe('typing', () => {
+    test('OptionalKeys match both optional and undefined keys', () => {
+      type T = { optional?: string, undef: string | undefined, required: string };
+      assertType<EqualTypes<OptionalKeys<T>, 'optional' | 'undef'>>(true)
+    });
     describe('simple type', () => {
       const validator = V.objectType()
         .properties({
@@ -318,6 +322,17 @@ describe('objects', () => {
           ComparableType<VType<typeof validator>>,
           // @ts-expect-error
           ComparableType<{
+            optional?: string;
+          }>
+        >;
+      });
+      test('required property is optional', () => {
+        // @ts-ignore
+        type v = EqualTypes<
+          // @ts-expect-error
+          ComparableType<VType<typeof validator>>,
+          ComparableType<{
+            required?: string;
             optional?: string;
           }>
         >;
@@ -340,6 +355,17 @@ describe('objects', () => {
           ComparableType<{
             required: string;
             optional?: number;
+          }>
+        >;
+      });
+      test('optional property is required', () => {
+        // @ts-ignore
+        type v = EqualTypes<
+          // @ts-expect-error
+          ComparableType<VType<typeof validator>>,
+          ComparableType<{
+            required: string;
+            optional: string;
           }>
         >;
       });
@@ -431,7 +457,7 @@ describe('objects', () => {
           }>
         >;
       });
-      test('required.optional should be required', () => {
+      test('required.optional is not optional', () => {
         // @ts-ignore
         type v = EqualTypes<
           // @ts-expect-error 
@@ -439,11 +465,28 @@ describe('objects', () => {
           ComparableType<{
             required: {
               required: string;
-              optional?: number;
+              optional: string;
             }
             optional?: {
               required: string;
-              optional: string;
+              optional?: string;
+            }
+          }>
+        >;
+      });
+      test('optional.required is not required', () => {
+        // @ts-ignore
+        type v = EqualTypes<
+          // @ts-expect-error 
+          ComparableType<VType<typeof validator>>,
+          ComparableType<{
+            required: {
+              required: string;
+              optional?: string;
+            }
+            optional?: {
+              required?: string;
+              optional?: string;
             }
           }>
         >;

--- a/packages/core/src/typing.ts
+++ b/packages/core/src/typing.ts
@@ -1,17 +1,36 @@
+/**
+ * Match both optional and "x | undefined" valued keys.
+ */
+export type OptionalKeys<T> =  Exclude<{
+  [K in keyof T]: undefined extends T[K] ? K : never;
+}[keyof T], undefined>;
 
-type KeysOfType<T, SelectedType> = {
-  [key in keyof T]: T[key] extends SelectedType ? key : never;
-}[keyof T];
+type OptionalProperties<T> = Pick<T, OptionalKeys<T>>;
+type RequiredProperties<T> = Omit<T, OptionalKeys<T>>;
 
-type OptionalProperties<T> = Pick<T, KeysOfType<T, undefined>>;
+type Optional<T> = { 'Optional<T>': T };
 
-type RequiredProperties<T> = Omit<T, KeysOfType<T, undefined>>;
+/**
+ * Wrap optional/undefined properties with required Optional<T> as TS only requires 
+ * that required properties match for types to be compatible.
+ */
+type ComparableOptional<T> = T extends object
+  ? { [K in keyof T]-?:  Optional<ComparableType<T[K]>> }
+  : T;
+
+type ComparableRequired<T> = T extends object
+  ? { [K in keyof T]:  ComparableType<T[K]> }
+  : T;
+
 
 export type UndefinedAsOptionalProperties<T> = RequiredProperties<T> & Partial<OptionalProperties<T>>;
 
-export type ComparableType<T> = T extends object ? Required<{
-    [K in keyof T]: ComparableType<Exclude<T[K], undefined>>;
-}>: Exclude<T, undefined>;
+/**
+ * Wrap all optional/undefined properties with Optional<T> recursively for strict type check
+ */
+export type ComparableType<T> = T extends object 
+  ? ComparableRequired<RequiredProperties<T>> & ComparableOptional<OptionalProperties<T>>
+  : T;
 
 /**
  * Verify mutual extensibility. When using this with both types wrapped in`ComparableType`, you get 


### PR DESCRIPTION
Type equality check doesn't make distinction between optional and required-undefined properties.