### PR TITLE
feat: internal validator architecture optimized for both sync and async rules

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,7 +23,7 @@ Or [`npm`](https://www.npmjs.com/):
 npm install @finnair/v-validation
 ```
 
-## Major Changes in Version 11
+## Major Changes Coming in Version 11
 
 Version 11 introduces better performing internal validator architecture. 
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,6 +23,17 @@ Or [`npm`](https://www.npmjs.com/):
 npm install @finnair/v-validation
 ```
 
+## Major Changes in Version 11
+
+Version 11 introduces better performing internal validator architecture. 
+
+This version refactors the internal architecture to be fully callback based which allows both synchronous and asynchronous validators to run without additional Promise/async-await overhead. From public API perspective (`Validator.validate/getValid`) nothing changes. Old and new validators can also be combined. However, **custom validators that extend internal validators (e.g. `ObjectValidator`) may need to be refactored**. 
+
+Performance was tested using ~126K MCT rules and resulted in around 3x faster validation (from 3 to 1 sec).
+
+**Drop support for ObjectValidator property filters**
+ObjectValidator's property filter (which was available for subclasses to utilize) has been dropped. That feature broke typing, and the use case to conditionally validate only selected properties, is nowdays better implemented with `V.if` and `ObjectValidator.pick/omit`.
+
 ## Major Changes in Version 8
 
 Drop (partial) support for cyclic data: There are cases where validation result (i.e. converted object) simply cannot retain cycles, e.g. the same object being validated with `V.oneOf` in different branches of the validator tree and resulting in different versions of the object. The rare use-cases for cyclic data simply do not justify the added complexity. 
@@ -624,22 +635,28 @@ V.map(...)
 
 // 3) If a validator doesn't have any parameters, but needs access to path and context,
 // it can be defined as a simple anonymous function
+// Depredated - use V.fn2 instead!
 V.fn((value: any, path: Path, ctx: ValidationContext): PromiseLike<ValidationResult> => {
   // return either successful or rejected Promise or throw an error
+})
+
+V.fn2((value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback) => {
+   // call either success or failure callback with the results (valid/converted value or Violations).
 })
 
 
 // 4) Full parametrizable validators extend Validator
 class MyValidator extends Validator {
-  // Validators should be immutable
+  // Validators should be immutable!
   constructor(public readonly myParameter: any) {
     super();
   }
-  async validatePath(value: any, path: Path, ctx: ValidationContext) {
+  // NOTE: validatePath() works is deprecated!
+  async validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     if (isOK(value)) {
-      return Promise.resolve(value);
+      return success(value);
     } else {
-      return Promise.reject(new MyViolation(path, myParameter, value));
+      return failure(new MyViolation(path, myParameter, value));
     }
   }
 }

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -733,45 +733,6 @@ describe('objects', () => {
     });
   });
 
-  describe('custom property filtering ObjectValidator extension', () => {
-    class DropAllPropertiesValidator<T> extends ObjectValidator<Partial<T>> {
-      constructor(model: ObjectModel) {
-        super(model);
-      }
-      /** @override */
-      validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Partial<T>>, failure: FailureCallback): void {
-        return this.validateFilteredPath(value, path, ctx, success, failure, _ => false);
-      }
-    }
-
-    test('required property validation skipped', async () =>
-      expectValid(
-        { property: 'to-be-dropped' },
-        new DropAllPropertiesValidator({
-          properties: { requiredProperty: V.string() }, // Not reported
-        }),
-        {},
-      ));
-
-    test('additional property validation skipped', async () =>
-      expectValid(
-        { foo: 'NaN' },
-        new DropAllPropertiesValidator({
-          additionalProperties: {
-            keys: V.hasValue('bar'),
-            values: V.integer(),
-          },
-        }),
-        {},
-      ));
-
-    test('filtered-out properties are dropped', async () => {
-      const result = await new DropAllPropertiesValidator({}).validate({ foo: 'foo', bar: 'bar' });
-      expect(result.isSuccess()).toBe(true);
-      expect(Object.keys(result.getValue()).length).toBe(0);
-    });
-  });
-
   describe('localProperties', () => {
     interface IParent {
       type: string;

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -513,7 +513,7 @@ describe('objects', () => {
     test('next allows conversion to string', () => {
       const validator = V.objectType()
         .properties({ value: V.string() })
-        .next(V.map( value => JSON.stringify(value) ))
+        .next(V.map(value => JSON.stringify(value)))
         .build();
       assertType<EqualTypes<VType<typeof validator>, string>>(true);
     });
@@ -523,7 +523,7 @@ describe('objects', () => {
     const validator = V.objectType().properties({ unknown: V.unknown() }).build();
     type T = { unknown: unknown };
     const value: T = { unknown: { foo: 'bar' } }
-    
+
     assertType<EqualTypes<ComparableType<VType<typeof validator>>, ComparableType<T>>>(true);
     const valid = await validator.getValid(value);
 
@@ -690,16 +690,16 @@ describe('objects', () => {
   describe('properties', () => {
     test('valid properties', async () => {
       const validator = V.properties(V.string(), V.string());
-      
-      assertType<EqualTypes<ComparableType<VType<typeof validator>>, ComparableType<{ [ key: string ]: string}>>>(true)
+
+      assertType<EqualTypes<ComparableType<VType<typeof validator>>, ComparableType<{ [key: string]: string }>>>(true)
       await expectValid({ foo: 'bar' }, validator);
     });
-    
+
     test('enum keys', async () => {
       enum Keys { A = 'A', B = 'B', C = 'C' };
       type type = { [key in Keys]?: number };
       const validator = V.optionalProperties(V.enum(Keys, 'Keys'), V.number());
-      
+
       assertType<EqualTypes<ComparableType<VType<typeof validator>>, ComparableType<type>>>(true)
       await expectValid({ A: 5 }, validator);
       await expectValid({ A: 1, B: 2, C: 3 }, validator);
@@ -946,7 +946,7 @@ describe('inheritance', () => {
       } satisfies VType<typeof multiParentChild>,
       multiParentChild,
     ));
-    
+
   test('invalid multi-parent object', () =>
     multiParentChild.validatePath({ additionalProperty: 123, name: '' }, Path.ROOT, new ValidationContext({})).then(
       (success) => {
@@ -1205,17 +1205,17 @@ describe('oneOf', () => {
 
     test('valid date', () => expectValid(validDateString, validator, validDate));
 
-    test('invalid value matching two', () => expectViolations(dateValue, validator, 
+    test('invalid value matching two', () => expectViolations(dateValue, validator,
       defaultViolations.oneOf(2, [
-        { success: true }, 
-        { success: true }, 
+        { success: true },
+        { success: true },
         { violations: [defaultViolations.enum('EnumType', dateValue, ROOT)] },
       ])));
 
-    test('no matches', () => expectViolations('ABD', validator, 
+    test('no matches', () => expectViolations('ABD', validator,
       defaultViolations.oneOf(0, [
-        { violations: [new HasValueViolation(ROOT, dateValue, 'ABD')] }, 
-        { violations: [defaultViolations.date('ABD', ROOT)] }, 
+        { violations: [new HasValueViolation(ROOT, dateValue, 'ABD')] },
+        { violations: [defaultViolations.date('ABD', ROOT)] },
         { violations: [defaultViolations.enum('EnumType', 'ABD', ROOT)] },
       ])));
   });
@@ -1520,11 +1520,11 @@ describe('async validation', () => {
     });
 
     test('invalid', async () => {
-      await expectViolations(true, V.oneOf(defer(V.number()), defer(V.string())), 
-      defaultViolations.oneOf(0, [
-        { violations: [new TypeMismatch(ROOT, 'number', true)] },
-        { violations: [new TypeMismatch(ROOT, 'string', true)] },
-      ]));
+      await expectViolations(true, V.oneOf(defer(V.number()), defer(V.string())),
+        defaultViolations.oneOf(0, [
+          { violations: [new TypeMismatch(ROOT, 'number', true)] },
+          { violations: [new TypeMismatch(ROOT, 'string', true)] },
+        ]));
     });
   });
 
@@ -1636,9 +1636,9 @@ describe('groups', () => {
       .otherwiseSuccess()
       .next(V.array(V.number()));
 
-    test('with normalization', () => expectGroupValid('1,2,3', normalize, optionalNormalization, [1,2,3]));
-    test('without normalization', () => expectValid([1,2,3], optionalNormalization));
-    test('invalid with normalization', () => expectGroupViolations([1,2,3], normalize, optionalNormalization, new ErrorViolation(ROOT, new TypeError('value.split is not a function'))));
+    test('with normalization', () => expectGroupValid('1,2,3', normalize, optionalNormalization, [1, 2, 3]));
+    test('without normalization', () => expectValid([1, 2, 3], optionalNormalization));
+    test('invalid with normalization', () => expectGroupViolations([1, 2, 3], normalize, optionalNormalization, new ErrorViolation(ROOT, new TypeError('value.split is not a function'))));
     test('invalid without normalization', () => expectViolations('1,2,3', optionalNormalization, new TypeMismatch(ROOT, 'array', '1,2,3')));
   });
 
@@ -1889,10 +1889,10 @@ describe('Map', () => {
   describe('toMapType', () => {
     const validator = V.toMapType(
       V.objectType()
-      .properties({ 
-        key1: V.required(V.string()), 
-        key2: V.required(V.string()),
-      }).build(),
+        .properties({
+          key1: V.required(V.string()),
+          key2: V.required(V.string()),
+        }).build(),
       V.string(),
       true,
     );
@@ -1905,7 +1905,7 @@ describe('Map', () => {
       expect(map.get(key)).toEqual('value');
       let result = (await validator.validate(map));
       expect(result.isFailure()).toBe(false);
-      result.getValue() satisfies JsonMap<{key1: string, key2: string}, string>
+      result.getValue() satisfies JsonMap<{ key1: string, key2: string }, string>
 
       // Serializes to JSON as array
       const jsonString = JSON.stringify(result.getValue());
@@ -1930,7 +1930,7 @@ describe('Map', () => {
     test('empty array component is not allowed', () => expectViolations([[]], validator, new SizeViolation(Path.of(0), 1, 2)));
 
     test('object is not allowed', () => expectViolations({}, validator, new TypeMismatch(Path.ROOT, 'Map OR array of [key, value] arrays')));
-    
+
     describe('typing', () => {
       test('JsonMap', () => {
         const validator = V.toMapType(V.string(), V.number(), true);
@@ -1953,7 +1953,7 @@ describe('Map', () => {
     test('Map has invalid value', () => expectViolations(new Map([['foo', 0]]), validator, new TypeMismatch(Path.of(0, 1), 'string', 0)));
 
     test('Map has invalid key', () => expectViolations(new Map([[0, 'foo']]), validator, new TypeMismatch(Path.of(0, 0), 'string', 0)));
-    
+
     describe('typing', () => {
       test('JsonMap', () => {
         const validator = V.mapType(V.string(), V.number(), true);
@@ -2017,7 +2017,7 @@ describe('Set', () => {
 
 describe('JsonBigInt', () => {
   const largeBigInt = 9007199254740993n;
-  
+
   test('JsonBigInt', async () => expectValid(new JsonBigInt(largeBigInt), V.jsonBigInt()));
   test('bigint', async () => expectValid(largeBigInt, V.jsonBigInt(), new JsonBigInt(largeBigInt)));
   test('string', async () => expectValid(largeBigInt.toString(), V.jsonBigInt(), new JsonBigInt(largeBigInt)));
@@ -2058,14 +2058,14 @@ describe('ValidationContext', () => {
   describe('deprecated api', () => {
     test('ValidationContext.failure', async () => {
       const violation = defaultViolations.unknownProperty(Path.of('foo'));
-     const result = await new ValidationContext({ ignoreUnknownProperties: true }).failure(violation, 'value');
-     expect(result).toEqual('value');
-     try {
-       await new ValidationContext({ ignoreUnknownProperties: false }).failure(violation, 'value');
-       fail('Expected an error');
+      const result = await new ValidationContext({ ignoreUnknownProperties: true }).failure(violation, 'value');
+      expect(result).toEqual('value');
+      try {
+        await new ValidationContext({ ignoreUnknownProperties: false }).failure(violation, 'value');
+        fail('Expected an error');
       } catch (e) {
         expect(e).toEqual([violation]);
-     }
+      }
     });
   });
 });

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -70,6 +70,16 @@ class DeferredValidator<T> extends Validator<T> {
   }
 }
 
+class DeprecatedValidator extends Validator<string> {
+  async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<string> {
+    if (String(value) === 'true') {
+      return Promise.resolve('true');
+    } else {
+      return Promise.reject(new Violation(path, 'DeprecatedValidator', value));
+    }
+  }
+}
+
 describe('ValidationResult', () => {
   test('getValue() returns valid value', async () => {
     const result = await V.string().validate('123');
@@ -225,7 +235,7 @@ describe('strings', () => {
 
     test('null is not allowed', () => expectViolations(null, V.size(1, 2), defaultViolations.notNull(ROOT)));
 
-    test('length is missing', () => expectViolations({}, V.size(1, 2), new TypeMismatch(ROOT, 'value with numeric length field')));
+    test('length is missing', () => expectViolations({}, V.size(1, 2), new TypeMismatch(ROOT, 'value with numeric length field', {})));
 
     test('length property', () => expectValid({ length: 2 }, V.size(1, 2)));
 
@@ -650,6 +660,14 @@ describe('objects', () => {
       await expectValid({ A: 1, B: 2, C: 3 }, validator);
       await expectViolations({ D: 4 }, validator, defaultViolations.enum('Keys', 'D', Path.of('D')));
     });
+    test('optionalProperties with deprecated validator', async () => {
+      const validator = V.optionalProperties(new DeprecatedValidator(), new DeprecatedValidator());
+      await expectValid({}, validator);
+      await expectValid({ 'true': 'true' }, validator);
+      await expectViolations({ 'true': 'false' }, validator, new Violation(Path.of('true'), 'DeprecatedValidator', 'false'));
+      await expectViolations({ 'false': 'true' }, validator, new Violation(Path.of('false'), 'DeprecatedValidator', 'false'));
+      await expectViolations({ 'false': 'false' }, validator, new Violation(Path.of('false'), 'DeprecatedValidator', 'false'));
+    });
   });
 
   describe('cross-property rules', () => {
@@ -927,13 +945,18 @@ describe('inheritance', () => {
       } satisfies VType<typeof multiParentChild>,
       multiParentChild,
     ));
+    
   test('invalid multi-parent object', () =>
-    expectViolations(
-      { additionalProperty: 123, name: '' },
-      multiParentChild,
-      defaultViolations.notEmpty(property('name')),
-      defaultViolations.notNull(property('anything')),
-      defaultViolations.notNull(property('id')),
+    multiParentChild.validatePath({ additionalProperty: 123, name: '' }, Path.ROOT, new ValidationContext({})).then(
+      (success) => {
+        fail(`expected violations, got ${success}`)
+      },
+      (violations) => {
+        expect(violations).toHaveLength(3);
+        expect(violations).toContainEqual(defaultViolations.notEmpty(property('name')));
+        expect(violations).toContainEqual(defaultViolations.notNull(property('anything')));
+        expect(violations).toContainEqual(defaultViolations.notNull(property('id')));
+      }
     ));
 
   test("child's extended property validators are only run after successful parent property validation", async () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -766,7 +766,7 @@ describe('objects', () => {
 
     test('recursive type', () => expectValid(({ first: 'first', next: { first: 'second', next: { first: 'third' } } }) satisfies VType<typeof validator>, validator));
 
-    test.skip('cyclic data is invalid ', async () => {
+    test('cyclic data is invalid ', async () => {
       const first: any = { first: 'first' };
       const second: any = { first: 'second', next: first };
       first.next = second;

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -979,12 +979,12 @@ describe('inheritance', () => {
   test('property order', async () => {
     const value = (
       await multiParentChild.validate({
-        id: '123',
-        name: 'multi-parent',
-        anything: true,
         firstAdditional: 'firstAdditional',
+        name: 'multi-parent',
         additionalProperty: 2,
         thirdAdditional: 'thirdAdditional',
+        anything: true,
+        id: '123',
       })
     ).getValue();
     expect(Object.keys(value)).toEqual(['id', 'name', 'anything', 'firstAdditional', 'additionalProperty', 'thirdAdditional']);

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -22,10 +22,8 @@ import {
   VType,
   JsonMap,
   JsonBigInt,
-  SuccessCallback,
-  FailureCallback,
 } from './validators.js';
-import { ObjectValidator, ObjectModel, VInheritableType } from './objectValidator.js';
+import { ObjectValidator, VInheritableType } from './objectValidator.js';
 import { V } from './V.js';
 import { jsonClone, Path } from '@finnair/path';
 import { expectUndefined, expectValid, expectViolations, verifyValid } from './testUtil.spec.js';
@@ -79,6 +77,13 @@ class DeprecatedValidator extends Validator<string> {
     }
   }
 }
+
+class ThrowingValidator extends Validator<string> {
+  public static readonly error = new Error('ThrowingValidator');
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: (value: string) => void, failure: (violations: Violation[]) => void): void {
+    throw ThrowingValidator.error;
+  }
+};
 
 describe('ValidationResult', () => {
   test('getValue() returns valid value', async () => {
@@ -545,92 +550,132 @@ describe('objects', () => {
 
   test('missing property value', () => expectViolations({}, validator, defaultViolations.notNull(property('requiredProperty'))));
 
-  test('requiredProperty should be a string', () =>
-    expectViolations(
-      {
-        requiredProperty: true,
-      },
-      validator,
-      new TypeMismatch(property('requiredProperty'), 'string', true),
-    ));
+  describe('additionalProperties', () => {
+    test('requiredProperty should be a string', () =>
+      expectViolations(
+        {
+          requiredProperty: true,
+        },
+        validator,
+        new TypeMismatch(property('requiredProperty'), 'string', true),
+      ));
 
-  describe('ignoreUnknownProperties', () => {
-    test('ignore unknown properties by default', () => {
-      const object = { unknownProperty: true };
-      return expectValid(object, V.object({}), object, { ignoreUnknownProperties: true });
-    });
-
-    test('log warning using warnLogger', async () => {
-      const object = { unknownProperty: true };
-      const warnings: Violation[] = [];
-      await expectValid(object, V.object({}), object, {
-        ignoreUnknownProperties: true,
-        warnLogger: (violation: Violation) => warnings.push(violation),
+    describe('ignoreUnknownProperties', () => {
+      test('ignore unknown properties by default', () => {
+        const object = { unknownProperty: true };
+        return expectValid(object, V.object({}), object, { ignoreUnknownProperties: true });
       });
-      expect(warnings).toEqual([defaultViolations.unknownProperty(property('unknownProperty'))]);
+
+      test('log warning using warnLogger', async () => {
+        const object = { unknownProperty: true };
+        const warnings: Violation[] = [];
+        await expectValid(object, V.object({}), object, {
+          ignoreUnknownProperties: true,
+          warnLogger: (violation: Violation) => warnings.push(violation),
+        });
+        expect(warnings).toEqual([defaultViolations.unknownProperty(property('unknownProperty'))]);
+      });
+
+      test('explicitly denied additionalProperties are still not allowed', async () => {
+        const object = { unknownProperty: true };
+        const result = await V.objectType().allowAdditionalProperties(false).build().validate(object, { ignoreUnknownProperties: true });
+        expect(result).toEqual(new ValidationResult([defaultViolations.unknownPropertyDenied(property('unknownProperty'))]));
+      });
     });
 
-    test('explicitly denied additionalProperties are still not allowed', async () => {
+    test('deny unknown/additional properties', async () => {
       const object = { unknownProperty: true };
-      const result = await V.objectType().allowAdditionalProperties(false).build().validate(object, { ignoreUnknownProperties: true });
+      const result = await V.object({ additionalProperties: false }).validate(object);
       expect(result).toEqual(new ValidationResult([defaultViolations.unknownPropertyDenied(property('unknownProperty'))]));
     });
-  });
 
-  test('deny unknown/additional properties', async () => {
-    const object = { unknownProperty: true };
-    const result = await V.object({ additionalProperties: false }).validate(object);
-    expect(result).toEqual(new ValidationResult([defaultViolations.unknownPropertyDenied(property('unknownProperty'))]));
-  });
+    test('additional properties not allowed', () =>
+      expectViolations(
+        {
+          requiredProperty: 'requiredProperty',
+          additionalProperty: 'additionalProperty',
+        },
+        validator,
+        defaultViolations.unknownProperty(property('additionalProperty')),
+      ));
 
-  test('additional properties not allowed', () =>
-    expectViolations(
-      {
-        requiredProperty: 'requiredProperty',
-        additionalProperty: 'additionalProperty',
-      },
-      validator,
-      defaultViolations.unknownProperty(property('additionalProperty')),
-    ));
-
-  test('additional properties allowed', () => {
-    const validator = V.object({
-      properties: {},
-      additionalProperties: true,
-    });
-    return expectValid(
-      {
-        additionalProperty: 'additionalProperty',
-      },
-      validator,
-    );
-  });
-
-  describe('extending additional property validations', () => {
-    const parent = V.object({
-      additionalProperties: {
-        keys: V.any(),
-        values: V.toInteger(),
-      },
-    });
-    const validator = V.object({
-      extends: parent,
-      additionalProperties: {
-        keys: V.any(),
-        values: V.min(1),
-      },
+    test('additional properties allowed', () => {
+      const validator = V.object({
+        properties: {},
+        additionalProperties: true,
+      });
+      return expectValid(
+        {
+          additionalProperty: 'additionalProperty',
+        },
+        validator,
+      );
     });
 
-    test('parent conversion is available for child validator', () => expectValid({ foo: '1' }, validator, { foo: 1 }));
+    describe('extending additional property validations', () => {
+      const parent = V.object({
+        additionalProperties: {
+          keys: V.any(),
+          values: V.toInteger(),
+        },
+      });
+      const validator = V.object({
+        extends: parent,
+        additionalProperties: {
+          keys: V.any(),
+          values: V.min(1),
+        },
+      });
 
-    test("invalid value for parent doesn't run child validator", () =>
-      expectViolations({ foo: 'a' }, validator, defaultViolations.number('a', NumberFormat.integer, property('foo'))));
+      test('parent conversion is available for child validator', () => expectValid({ foo: '1' }, validator, { foo: 1 }));
 
-    test('invalid value for child validator', () => expectViolations({ foo: 0 }, validator, defaultViolations.min(1, true, 0, property('foo'))));
+      test("invalid value for parent doesn't run child validator", () =>
+        expectViolations({ foo: 'a' }, validator, defaultViolations.number('a', NumberFormat.integer, property('foo'))));
+
+      test('invalid value for child validator', () => expectViolations({ foo: 0 }, validator, defaultViolations.min(1, true, 0, property('foo'))));
+    });
+
+    test('disallow all properties', () =>
+      expectViolations({ property: 'value' }, V.object({ additionalProperties: false }), defaultViolations.unknownPropertyDenied(ROOT.property('property'))));
+
+    describe('additionalProperty rules', () => {
+      const allowXString = V.objectType()
+        .additionalProperties(V.pattern(/^x-.+/), V.string())
+        .build();
+      assertType<EqualTypes<ComparableType<VType<typeof allowXString>>, ComparableType<Partial<Record<string, string>>>>>(true);
+
+      const allowYStringRestrictX = V.object({
+        extends: allowXString,
+        additionalProperties: [
+          {
+            keys: V.pattern(/^y-.+/),
+            values: V.string(),
+          },
+          {
+            keys: V.pattern(/^x-.+/),
+            values: V.check(V.toInteger()),
+          },
+        ],
+      });
+
+      test('x-property: "foo" allowed', () => expectValid({ 'x-property': 'foo' }, allowXString));
+
+      test('x-property: 123 not allowed', () => expectViolations({ 'x-property': 123 }, allowXString, defaultViolations.string(123, property('x-property'))));
+
+      test('y-property not allowed', () =>
+        expectViolations({ 'y-property': 'foo' }, allowXString, defaultViolations.pattern(/^x-.+/, 'y-property', property('y-property'))));
+
+      test('y-property allowed', () => expectValid({ 'y-property': 'foo' }, allowYStringRestrictX));
+
+      test('x-property restricted to numeric string', () =>
+        expectViolations({ 'x-property': 'foo' }, allowYStringRestrictX, defaultViolations.number('foo', NumberFormat.integer, property('x-property'))));
+
+      test('x-property numeric string is valid', () => expectValid({ 'x-property': '123' }, allowYStringRestrictX));
+
+      test('z-property not allowed', () =>
+        expectViolations({ 'z-property': 'foo' }, allowYStringRestrictX, defaultViolations.unknownProperty(property('z-property'))));
+    });
   });
-
-  test('disallow all properties', () =>
-    expectViolations({ property: 'value' }, V.object({ additionalProperties: false }), defaultViolations.unknownPropertyDenied(ROOT.property('property'))));
 
   test('string not allowed', () => expectViolations('string', V.object({}), defaultViolations.object(ROOT)));
 
@@ -820,44 +865,39 @@ describe('objects', () => {
       expectValid(value, pick);
     })
   });
-});
 
-describe('additionalProperties', () => {
-  const allowXString = V.objectType()
-    .additionalProperties(V.pattern(/^x-.+/), V.string())
-    .build();
-  assertType<EqualTypes<ComparableType<VType<typeof allowXString>>, ComparableType<Partial<Record<string, string>>>>>(true);
-
-  const allowYStringRestrictX = V.object({
-    extends: allowXString,
-    additionalProperties: [
-      {
-        keys: V.pattern(/^y-.+/),
-        values: V.string(),
-      },
-      {
-        keys: V.pattern(/^x-.+/),
-        values: V.check(V.toInteger()),
-      },
-    ],
+  describe('thrown errors', () => {
+    test('all propertiers throwing', async () => {
+      const result = await V.objectType()
+        .properties({
+          property: new ThrowingValidator(),
+        })
+        .localProperties({
+          localProperty: new ThrowingValidator(),
+        })
+        .additionalProperties(V.string(), new ThrowingValidator())
+        .build()
+        .validate({
+          additional: 'additional',
+        });
+      expect(result.getViolations()).toEqual([
+        new ErrorViolation(property('property'), ThrowingValidator.error),
+        new ErrorViolation(property('localProperty'), ThrowingValidator.error),
+        new ErrorViolation(property('additional'), ThrowingValidator.error),
+      ]);
+    });
+    test('additional property key throwing', async () => {
+      const result = await V.objectType()
+        .additionalProperties(new ThrowingValidator(), V.string())
+        .build()
+        .validate({
+          additional: 'additional',
+        });
+      expect(result.getViolations()).toEqual([
+        new ErrorViolation(property('additional'), ThrowingValidator.error),
+      ]);
+    });
   });
-
-  test('x-property: "foo" allowed', () => expectValid({ 'x-property': 'foo' }, allowXString));
-
-  test('x-property: 123 not allowed', () => expectViolations({ 'x-property': 123 }, allowXString, defaultViolations.string(123, property('x-property'))));
-
-  test('y-property not allowed', () =>
-    expectViolations({ 'y-property': 'foo' }, allowXString, defaultViolations.pattern(/^x-.+/, 'y-property', property('y-property'))));
-
-  test('y-property allowed', () => expectValid({ 'y-property': 'foo' }, allowYStringRestrictX));
-
-  test('x-property restricted to numeric string', () =>
-    expectViolations({ 'x-property': 'foo' }, allowYStringRestrictX, defaultViolations.number('foo', NumberFormat.integer, property('x-property'))));
-
-  test('x-property numeric string is valid', () => expectValid({ 'x-property': '123' }, allowYStringRestrictX));
-
-  test('z-property not allowed', () =>
-    expectViolations({ 'z-property': 'foo' }, allowYStringRestrictX, defaultViolations.unknownProperty(property('z-property'))));
 });
 
 describe('inheritance', () => {
@@ -1303,6 +1343,15 @@ describe('arrays', () => {
 
     test('too long', () => expectViolations([1, 2], V.size(1, 1), defaultViolations.size(1, 1)));
   });
+
+  test('thrown errors', async () => {
+    const validator = V.array(new ThrowingValidator());
+    const result = await validator.validate([1]);
+    expect(result.isSuccess()).toBe(false);
+    const violations = result.getViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toBeInstanceOf(ErrorViolation);
+  });
 });
 
 describe('number', () => {
@@ -1435,7 +1484,7 @@ describe('null or undefined', () => {
 
 describe('async validation', () => {
   describe('allOf', () => {
-    test('results ordered by timeout', async () => {
+    test('violations ordered by timeout', async () => {
       const validator = V.allOf(defer(V.notEmpty(), 10), defer(V.toNumber(), 5), V.date());
       await expectViolations(
         '',
@@ -1916,6 +1965,18 @@ describe('Map', () => {
       });
     });
   });
+
+  test('empty map is valid', async () => expectValid(new Map(), V.mapType(V.string(), V.string(), false)));
+
+  test('thrown errors', async () => {
+    const result = await V.mapType(new ThrowingValidator(), new ThrowingValidator(), false)
+      .validate(new Map([['key', 'value']]));
+    expect(result.isSuccess()).toBe(false);
+    const violations = result.getViolations();
+    expect(violations).toHaveLength(2);
+    expect(violations[0]).toBeInstanceOf(ErrorViolation);
+    expect(violations[1]).toBeInstanceOf(ErrorViolation);
+  });
 });
 
 describe('Set', () => {
@@ -1928,6 +1989,8 @@ describe('Set', () => {
   test('object is not valid', () => expectViolations({}, V.setType(V.number(), false), new TypeMismatch(ROOT, 'Set')));
 
   test('Set has invalid value', () => expectViolations(new Set(['foo']), V.setType(V.number(), false), new TypeMismatch(Path.of(0), 'number', 'foo')));
+
+  test('empty set is valida', async () => expectValid(new Set(), V.setType(V.number(), false)));
 
   test('json round-trip', async () => {
     const setArray = [1, 2, 3];
@@ -1991,6 +2054,22 @@ describe('JsonBigInt', () => {
   });
 });
 
+describe('ValidationContext', () => {
+  describe('deprecated api', () => {
+    test('ValidationContext.failure', async () => {
+      const violation = defaultViolations.unknownProperty(Path.of('foo'));
+     const result = await new ValidationContext({ ignoreUnknownProperties: true }).failure(violation, 'value');
+     expect(result).toEqual('value');
+     try {
+       await new ValidationContext({ ignoreUnknownProperties: false }).failure(violation, 'value');
+       fail('Expected an error');
+      } catch (e) {
+        expect(e).toEqual([violation]);
+     }
+    });
+  });
+});
+
 describe('json', () => {
   const validator = V.json(V.array(V.string()));
 
@@ -2005,4 +2084,67 @@ describe('json', () => {
   test('Invalid JSON', () => expectViolations('["foo", "bar"', validator, new TypeMismatch(Path.of(), 'JSON', '["foo", "bar"')));
 
   test('Non-string input is invalid', () => expectViolations(123 as any, validator, new TypeMismatch(Path.of(), 'string', 123)));
+});
+
+describe('fn', () => {
+  test('synchronous', async () => {
+    const result = await V.fn((value: string) => value.toUpperCase()).getValid('test');
+    expect(result).toEqual('TEST');
+  });
+  test('asynchronous', async () => {
+    const result = await V.fn(async (value: string) => value.toUpperCase()).getValid('test');
+    expect(result).toEqual('TEST');
+  });
+  test('Throws Error', async () => {
+    const error = new Error('Error message');
+    try {
+      await V.fn(() => { throw error; }).getValid('test');
+      fail('Expected an error');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      const violation = (e as ValidationError).violations[0];
+      expect(violation).toBeInstanceOf(ErrorViolation);
+      expect((violation as ErrorViolation).error).toBe(error);
+    }
+  });
+  test('Throws ignored violation', async () => {
+    const violation = defaultViolations.unknownProperty(Path.of('foo'));
+    const result = await V.fn(() => { throw violation; }).getValid('test', { ignoreUnknownProperties: true });
+    expect(result).toEqual('test');
+  });
+});
+
+describe('fn2', () => {
+  test('successful', async () => {
+    const result = await V.fn2((value: string, _path, _ctx, success) => success(value.toUpperCase())).getValid('test');
+    expect(result).toEqual('TEST');
+  });
+  test('failure', async () => {
+    const violation = defaultViolations.string(123);
+    const result = await V.fn2((_value, _path, _ctx, _success, failure) => failure(violation)).validate(123);
+    expect(result.isFailure()).toBe(true);
+    expect(result.getViolations()).toEqual([violation]);
+  });
+  test('Throws Error', async () => {
+    const error = new Error('Error message');
+    try {
+      await V.fn2(() => { throw error; }).getValid('test');
+      fail('Expected an error');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      const violation = (e as ValidationError).violations[0];
+      expect(violation).toBeInstanceOf(ErrorViolation);
+      expect((violation as ErrorViolation).error).toBe(error);
+    }
+  });
+  test('Throws ignored violation', async () => {
+    const violation = defaultViolations.unknownProperty(Path.of('foo'));
+    const result = await V.fn2(() => { throw violation; }).getValid('test', { ignoreUnknownProperties: true });
+    expect(result).toEqual('test');
+  });
+  test('Reports ignored violation', async () => {
+    const violation = defaultViolations.unknownProperty(Path.of('foo'));
+    const result = await V.fn2((_value, _path, _ctx, _success, failure) => { failure(violation) }).getValid('test', { ignoreUnknownProperties: true });
+    expect(result).toEqual('test');
+  });
 });

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1012,6 +1012,16 @@ describe('inheritance', () => {
 
     test('invalid child', () => expectViolations({ pwd1: 'pwd1', pwd2: 'pwd2', min: 2, max: 1 }, child, new Violation(ROOT, 'PasswordsMatch'), new Violation(ROOT, 'MinLoeMax')));
   });
+
+  test('prototype inheritance', async () => {
+    const parent = { parentProp: 'parentProp' };
+    const child = Object.create(parent);
+    await expectViolations(
+      child,
+      V.objectType().allowAdditionalProperties(false).build(), 
+      defaultViolations.unknownPropertyDenied(ROOT.property('parentProp'))
+    );
+  });
 });
 
 describe('object next', () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -22,6 +22,8 @@ import {
   VType,
   JsonMap,
   JsonBigInt,
+  SuccessCallback,
+  FailureCallback,
 } from './validators.js';
 import { ObjectValidator, ObjectModel, VInheritableType } from './objectValidator.js';
 import { V } from './V.js';
@@ -701,7 +703,7 @@ describe('objects', () => {
 
     test('recursive type', () => expectValid(({ first: 'first', next: { first: 'second', next: { first: 'third' } } }) satisfies VType<typeof validator>, validator));
 
-    test('cyclic data is invalid ', async () => {
+    test.skip('cyclic data is invalid ', async () => {
       const first: any = { first: 'first' };
       const second: any = { first: 'second', next: first };
       first.next = second;
@@ -718,8 +720,9 @@ describe('objects', () => {
       constructor(model: ObjectModel) {
         super(model);
       }
-      validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<Partial<T>> {
-        return this.validateFilteredPath(value, path, ctx, _ => false);
+      /** @override */
+      validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Partial<T>>, failure: FailureCallback): void {
+        return this.validateFilteredPath(value, path, ctx, success, failure, _ => false);
       }
     }
 
@@ -928,9 +931,9 @@ describe('inheritance', () => {
     expectViolations(
       { additionalProperty: 123, name: '' },
       multiParentChild,
+      defaultViolations.notEmpty(property('name')),
       defaultViolations.notNull(property('anything')),
       defaultViolations.notNull(property('id')),
-      defaultViolations.notEmpty(property('name')),
     ));
 
   test("child's extended property validators are only run after successful parent property validation", async () => {

--- a/packages/core/src/V.ts
+++ b/packages/core/src/V.ts
@@ -56,6 +56,8 @@ import {
   NullableValidator,
   JsonBigIntValidator,
   UnknownValidator,
+  ValidatorFnV2,
+  ValidatorFnWrapperV2,
 } from './validators.js';
 import {ObjectModel, ObjectValidator, ObjectNormalizer } from './objectValidator.js';
 import { ObjectValidatorBuilder } from './objectValidatorBuilder.js';
@@ -87,6 +89,8 @@ const ignoreValidator = new IgnoreValidator(),
 
 export const V = {
   fn: <Out, In>(fn: ValidatorFn<Out, In>, type?: string) => new ValidatorFnWrapper<Out, In>(fn, type),
+
+  fn2: <Out, In>(fn: ValidatorFnV2<Out, In>, type?: string) => new ValidatorFnWrapperV2<Out, In>(fn, type),
 
   map: <Out, In>(fn: MappingFn<Out, In>, error?: any) => new ValueMapper<Out, In>(fn, error),
 

--- a/packages/core/src/V.ts
+++ b/packages/core/src/V.ts
@@ -59,7 +59,7 @@ import {
   ValidatorFnV2,
   ValidatorFnWrapperV2,
 } from './validators.js';
-import {ObjectModel, ObjectValidator, ObjectNormalizer } from './objectValidator.js';
+import {ObjectModel, ObjectValidator, ObjectNormalizer, PropertiesValidator, MapEntryValidator } from './objectValidator.js';
 import { ObjectValidatorBuilder } from './objectValidatorBuilder.js';
 
 interface AllOfParameters {
@@ -207,10 +207,10 @@ export const V = {
   size: <T extends { length: number }>(min: number, max: number) => new SizeValidator<T>(min, max),
 
   properties: <Key extends keyof any, Value>(keys: Validator<Key>, values: Validator<Value>) => 
-    new ObjectValidator<Record<Key, Value>>({ additionalProperties: { keys, values } }),
+    new PropertiesValidator<Record<Key, Value>>({}, {}, [new MapEntryValidator({ keys, values })]),
 
   optionalProperties: <Key extends keyof any, Value>(keys: Validator<Key>, values: Validator<Value>) => 
-    new ObjectValidator<Partial<Record<Key, Value>>>({ additionalProperties: { keys, values } }),
+    new PropertiesValidator<Partial<Record<Key, Value>>>({}, {}, [new MapEntryValidator({ keys, values })]),
 
   allOf: AllOfConstructor,
 

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -162,9 +162,14 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
     }
     const anyValue = value as any;
     const convertedObject: any = {} as LocalType;
-    const keys = new Set<string>([...Object.keys(this.properties), ...Object.keys(this.localProperties), ...Object.keys(value)]);
-    let expectedResponses = keys.size;
     let violations: Violation[] = [];
+    
+    const keys = new Set<string>([...Object.keys(this.properties), ...Object.keys(this.localProperties)]);
+    // Add all, including inherited keys
+    for (const key in anyValue) {
+      keys.add(key);
+    }
+    let expectedResponses = keys.size;
 
     if (expectedResponses === 0) {
       return success(convertedObject as LocalType);

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -124,12 +124,10 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback): void {
     if (value === null || value === undefined) {
-      failure([defaultViolations.notNull(path)]);
-      return;
+      return failure([defaultViolations.notNull(path)]);
     }
     if (typeof value !== 'object' || Array.isArray(value)) {
-      failure([defaultViolations.object(path)]);
-      return;
+      return failure([defaultViolations.object(path)]);
     }
     const anyValue = value as any;
     const convertedObject: any = {} as LocalType;
@@ -138,8 +136,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     let violations: Violation[] = [];
 
     if (expectedResponses === 0) {
-      success(convertedObject as LocalType);
-      return;
+      return success(convertedObject as LocalType);
     }
 
     const reportResult = () => {
@@ -294,16 +291,14 @@ export class ObjectNormalizer<InOut> extends Validator<undefined | InOut | {}> {
   }
   validatePathV2(value: InOut, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined | InOut | {}>, failure: FailureCallback): void {
     if (value === undefined) {
-      success(undefined);
-      return;
+      return success(undefined);
     }
     if (typeof value !== 'object' || value === null) {
       const object: any = {};
       object[this.property] = value;
-      success(object);
-      return;
+      return success(object);
     }
-    success(value);
+    return success(value);
   }
 }
 

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -3,17 +3,19 @@ import {
   AnyValidator, 
   CompositionParameters, 
   defaultViolations, 
+  FailureCallback, 
   HasValueValidator, 
   isNullOrUndefined, 
   isNumber, 
   isString, 
   maybeAllOfValidator, 
   maybeCompositionOf, 
+  SuccessCallback, 
   ValidationContext, 
   Validator, 
-  ValidatorFnWrapper, 
-  Violation, 
-  violationsOf,
+  ValidatorFnWrapperV2, 
+  Violation,
+  violationsOf, 
 } from "./validators";
 
 export type PropertyModel = { [s: string]: string | number | Validator };
@@ -120,62 +122,126 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<LocalType> {
-    return this.validateFilteredPath(value, path, ctx, _ => true);
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback): void {
+    this.validateFilteredPath(value, path, ctx, success, failure, _ => true);
   }
 
-  validateFilteredPath(value: In, path: Path, ctx: ValidationContext, filter: PropertyFilter): PromiseLike<LocalType> {
+  validateFilteredPath(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback, filter: PropertyFilter) {
     if (value === null || value === undefined) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure([defaultViolations.notNull(path)]);
+      return;
     }
     if (typeof value !== 'object' || Array.isArray(value)) {
-      return Promise.reject(defaultViolations.object(path));
+      failure([defaultViolations.object(path)]);
+      return;
     }
     const anyValue = value as any;
-    const context: ObjectValidationContext = {
-      path,
-      ctx,
-      filter,
-      convertedObject: {} as LocalType,
-      violations: [],
+    const convertedObject: any = {} as LocalType;
+    const keys = new Set<string>([...Object.keys(this.properties), ...Object.keys(this.localProperties), ...Object.keys(value)]);
+    let expectedResponses = keys.size;
+    let violations: Violation[] = [];
+
+    const reportResult = () => {
+      if (--expectedResponses === 0) {
+        if (violations.length > 0) {
+          failure(violations);
+        } else if (this.nextValidator) {
+          this.nextValidator.validatePathV2(convertedObject, path, ctx, 
+            (result) => {
+              if (this.localNextValidator) {
+                this.localNextValidator.validatePathV2(result, path, ctx, (result) => success(result as LocalType), failure);
+              } else {
+                success(result as LocalType);
+              }
+            }, 
+            failure);
+        } else if (this.localNextValidator) {
+          this.localNextValidator.validatePathV2(convertedObject, path, ctx, (result) => success(result as LocalType), failure);
+        } else {
+          success(convertedObject as LocalType);
+        }
+      }
     };
-    const propertyResults: PromiseLike<any>[] = [];
 
-    for (const key in this.properties) {
-      propertyResults.push(validateProperty(key, anyValue[key], this.properties[key], context));
-    }
-    for (const key in this.localProperties) {
-      propertyResults.push(validateProperty(key, anyValue[key], this.localProperties[key], context));
-    }
-    for (const key in value) {
-      if (!this.properties[key] && !this.localProperties[key]) {
-        propertyResults.push(validateAdditionalProperty(key, anyValue[key], this.additionalProperties, context));
+    const reportSuccess = (key: string, propertyValue: unknown) => {
+      if (propertyValue !== undefined) {
+        convertedObject[key] = propertyValue;
+      } else {
+        delete convertedObject[key];
+      }
+      reportResult();
+    };
+    
+    const reportFailure = (key: string, error: any) => {
+      delete convertedObject[key];
+      violations = violations.concat(violationsOf(error, path.property(key)));
+      reportResult();
+    };
+    
+    const validateLocalProperty = (key: string, propertyValue: unknown, propertyPath: Path) => {
+      this.localProperties[key].validatePathV2(propertyValue, propertyPath, ctx, 
+        (result) => reportSuccess(key, result),
+        (error) => reportFailure(key, error)
+      )
+    };
+
+    const validateProperty = (key: string, propertyValue: unknown, propertyPath: Path) => {
+      this.properties[key].validatePathV2(propertyValue, propertyPath, ctx, 
+        (result) => {
+          if (this.localProperties[key]) {
+            validateLocalProperty(key, propertyValue, propertyPath);
+          } else {
+            reportSuccess(key, result);
+          }
+        },
+        (error) => reportFailure(key, error)
+      )
+    };
+
+    const validateAdditionalProperty = (key: string, propertyValue: unknown, propertyPath: Path, index: number, keySuccessCount: number, keyError?: Violation[]) => {
+      if (index < this.additionalProperties.length) {
+        const { keyValidator, valueValidator } = this.additionalProperties[index];
+        keyValidator.validatePathV2(key, propertyPath, ctx, 
+          () => {
+            valueValidator.validatePathV2(propertyValue, propertyPath, ctx,
+              (result) => validateAdditionalProperty(key, result, propertyPath, index + 1, keySuccessCount + 1),
+              (error) => reportFailure(key, error)
+            );
+          },
+          (keyError) => validateAdditionalProperty(key, propertyValue, propertyPath, index + 1, keySuccessCount, keyError)
+        );
+      } else if (keySuccessCount === 0) {
+        ctx.failureV2(defaultViolations.unknownProperty(propertyPath), propertyValue,
+          (result) => reportSuccess(key, result),
+          (error) => {
+            if (index === 1 && keyError) {
+              reportFailure(key, keyError);
+            } else {
+              reportFailure(key, error);
+            }
+          }
+        );
+      } else {
+        reportSuccess(key, propertyValue);
+      }
+    };
+
+    for (const key of keys) {
+      convertedObject[key] = undefined;
+      if (!filter(key)) {
+        reportSuccess(key, undefined);
+        continue;
+      }
+      const valuePath = path.property(key);
+      const propertyValue = anyValue[key];
+      if (this.properties[key]) {
+        validateProperty(key, propertyValue, valuePath);
+      } else if (this.localProperties[key]) {
+        validateLocalProperty(key, propertyValue, valuePath);
+      } else {
+        validateAdditionalProperty(key, propertyValue, valuePath, 0, 0);
       }
     }
-
-    let validationChain = Promise.allSettled(propertyResults).then(_ => {
-      if (context.violations.length === 0) {
-        return Promise.resolve(context.convertedObject);
-      }
-      return Promise.reject(context.violations);
-    });
-    if (this.nextValidator) {
-      const validator = this.nextValidator;
-      validationChain = validationChain.then(
-        result => {
-          return validator.validatePath(result, path, ctx);
-        }
-      );
-    }
-    if (this.localNextValidator) {
-      const validator = this.localNextValidator;
-      validationChain = validationChain.then(
-        result => {
-          return validator.validatePath(result, path, ctx);
-        }
-      );
-    }
-    return validationChain;
   }
 
   omit<T, K extends keyof (any & (InheritableType | LocalType))>(...keys: K[]) {
@@ -200,75 +266,6 @@ function pick(properties: Properties, fn: (key: keyof any) => boolean): Properti
     }
     return current;
   }, {} as Properties);
-}
-
-interface ObjectValidationContext {
-  readonly path: Path;
-  readonly ctx: ValidationContext;
-  readonly filter: PropertyFilter;
-  readonly convertedObject: any;
-  violations: Violation[];
-}
-
-function validateProperty(key: string, currentValue: any, validator: Validator, context: ObjectValidationContext) {
-  if (!context.filter(key)) {
-    return Promise.resolve();
-  }
-  // Assign for property order
-  context.convertedObject[key] = undefined;
-  const propertyPath = context.path.property(key);
-  return validator.validatePath(currentValue, propertyPath, context.ctx).then(
-    (result) => {
-      if (result !== undefined) {
-        context.convertedObject[key] = result;
-      } else {
-        delete context.convertedObject[key];
-      }
-      return result;
-    },
-    (error) => {
-      delete context.convertedObject[key];
-      context.violations = context.violations.concat(violationsOf(error, propertyPath));
-      return Promise.reject(context.violations);
-    }
-  );
-}
-
-async function validateAdditionalProperty(
-  key: string,
-  originalValue: any,
-  additionalProperties: MapEntryValidator[],
-  context: ObjectValidationContext,
-): Promise<any> {
-  if (!context.filter(key)) {
-    return Promise.resolve();
-  }
-  const path = context.path.property(key);
-  let currentValue = originalValue;
-  let validKey = false;
-  let keyViolations: undefined | Violation[];
-  for (let i = 0; i < additionalProperties.length; i++) {
-    const entryValidator = additionalProperties[i];
-    try {
-      await entryValidator.keyValidator.validatePath(key, path, context.ctx);
-      validKey = true;
-      try {
-        currentValue = await validateProperty(key, currentValue, entryValidator.valueValidator, context);
-      } catch (error) {
-        return Promise.reject(violationsOf(error, path));
-      }
-    } catch (error) {
-      keyViolations = violationsOf(error, path);
-    }
-  }
-  if (!validKey) {
-    if (additionalProperties.length == 1 && keyViolations) {
-      // Only one kind of key accepted -> give out violations related to that
-      context.violations = context.violations.concat(keyViolations);
-    } else {
-      return validateProperty(key, originalValue, lenientUnknownPropertyValidator, context);
-    }
-  }
 }
 
 export function mergeProperties(from: Properties, to: Properties): Properties {
@@ -350,11 +347,11 @@ function getMapEntryValidators(additionalProperties?: boolean | MapEntryModel | 
   return validators;
 }
 
-export const lenientUnknownPropertyValidator = new ValidatorFnWrapper((value: any, path: Path, ctx: ValidationContext) =>
-  ctx.failure(defaultViolations.unknownProperty(path), value));
+export const lenientUnknownPropertyValidator = new ValidatorFnWrapperV2((value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<any>, failure: FailureCallback) =>
+  ctx.failureV2(defaultViolations.unknownProperty(path), value, success, failure));
 
-export const strictUnknownPropertyValidator = new ValidatorFnWrapper((value: any, path: Path, ctx: ValidationContext) => 
-  Promise.reject(defaultViolations.unknownPropertyDenied(path)));
+export const strictUnknownPropertyValidator = new ValidatorFnWrapperV2((value: any, path: Path, ctx: ValidationContext, _success: SuccessCallback<any>, failure: FailureCallback) => 
+  failure([defaultViolations.unknownPropertyDenied(path)]));
 
 const allowAllMapEntries: MapEntryValidator = new MapEntryValidator({
   keys: new AnyValidator(),

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -141,6 +141,11 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     let expectedResponses = keys.size;
     let violations: Violation[] = [];
 
+    if (expectedResponses === 0) {
+      success(convertedObject as LocalType);
+      return;
+    }
+
     const reportResult = () => {
       if (--expectedResponses === 0) {
         if (violations.length > 0) {
@@ -234,12 +239,16 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
       }
       const valuePath = path.property(key);
       const propertyValue = anyValue[key];
-      if (this.properties[key]) {
-        validateProperty(key, propertyValue, valuePath);
-      } else if (this.localProperties[key]) {
-        validateLocalProperty(key, propertyValue, valuePath);
-      } else {
-        validateAdditionalProperty(key, propertyValue, valuePath, 0, 0);
+      try {
+        if (this.properties[key]) {
+          validateProperty(key, propertyValue, valuePath);
+        } else if (this.localProperties[key]) {
+          validateLocalProperty(key, propertyValue, valuePath);
+        } else {
+          validateAdditionalProperty(key, propertyValue, valuePath, 0, 0);
+        }
+      } catch (error) {
+        reportFailure(key, error);
       }
     }
   }
@@ -291,16 +300,18 @@ export class ObjectNormalizer<InOut> extends Validator<undefined | InOut | {}> {
     super();
     Object.freeze(this);
   }
-  validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<undefined | {}> {
+  validatePathV2(value: InOut, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined | InOut | {}>, failure: FailureCallback): void {
     if (value === undefined) {
-      return Promise.resolve(undefined);
+      success(undefined);
+      return;
     }
     if (typeof value !== 'object' || value === null) {
       const object: any = {};
       object[this.property] = value;
-      return Promise.resolve(object);
+      success(object);
+      return;
     }
-    return Promise.resolve(value);
+    success(value);
   }
 }
 

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -76,7 +76,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
 
   public readonly nextValidator?: Validator;
 
-  public readonly localNextValidator?: Validator;
+  private readonly validator: Validator<LocalType, In>;
 
   constructor(public readonly model: ObjectModel<LocalType, InheritableType>) {
     super();
@@ -103,25 +103,56 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     this.additionalProperties = additionalProperties.concat(getMapEntryValidators(model.additionalProperties));
     this.properties = mergeProperties(getPropertyValidators(model.properties), properties);
     this.localProperties = getPropertyValidators(model.localProperties);
+
+    let validator: Validator = new PropertiesValidator<LocalType, In>(this.properties, this.localProperties, this.additionalProperties);
     const next = nextValidators.length > 0 ? maybeCompositionOf(...(nextValidators as CompositionParameters)) : undefined;
     if (next) {
       this.nextValidator = next;
+      validator = validator.next(next);
     }
     if (model.localNext) {
+      let localNextValidator: Validator | undefined = undefined;
       if (!Array.isArray(model.localNext)) {
-        this.localNextValidator = model.localNext;
+        localNextValidator = model.localNext;
       } else if (model.localNext.length > 0) {
-        this.localNextValidator = maybeCompositionOf(...(model.localNext as CompositionParameters));
+        localNextValidator = maybeCompositionOf(...(model.localNext as CompositionParameters));
+      }
+      if (localNextValidator) {
+        validator = validator.next(localNextValidator);
       }
     }
-
-    Object.freeze(this.properties);
-    Object.freeze(this.localProperties);
-    Object.freeze(this.additionalProperties);
+    this.validator = validator as Validator<LocalType, In>;
     Object.freeze(this.parentValidators);
     Object.freeze(this);
   }
 
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback): void {
+    this.validator.validatePathV2(value, path, ctx, success, failure);
+  }
+
+  omit<T, K extends keyof (any & (InheritableType | LocalType))>(...keys: K[]) {
+    return new ObjectValidator<Omit<LocalType, K extends keyof LocalType ? K : never>, Omit<InheritableType, K extends keyof InheritableType ? K : never>>({
+      properties: pick(this.properties, key => !keys.includes(key as any)),
+      localProperties: pick(this.localProperties, key => !keys.includes(key as any)),
+    });
+  }
+
+  pick<T, K extends keyof (any & (InheritableType | LocalType))>(...keys: K[]) {
+    return new ObjectValidator<Pick<LocalType, K extends keyof LocalType ? K : never>, Pick<InheritableType, K extends keyof InheritableType ? K : never>>({
+      properties: pick(this.properties, key => keys.includes(key as any)),
+      localProperties: pick(this.localProperties, key => keys.includes(key as any)),
+    });
+  }
+}
+
+export class PropertiesValidator<LocalType = unknown, In = unknown> extends Validator<LocalType, In> {
+  constructor(readonly properties: Properties, readonly localProperties: Properties, readonly additionalProperties: MapEntryValidator[]) {
+    super();
+    Object.freeze(this.properties);
+    Object.freeze(this.localProperties);
+    Object.freeze(this.additionalProperties);
+    Object.freeze(this);
+  }
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback): void {
     if (value === null || value === undefined) {
       return failure([defaultViolations.notNull(path)]);
@@ -143,18 +174,6 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
       if (--expectedResponses === 0) {
         if (violations.length > 0) {
           failure(violations);
-        } else if (this.nextValidator) {
-          this.nextValidator.validatePathV2(convertedObject, path, ctx, 
-            (result) => {
-              if (this.localNextValidator) {
-                this.localNextValidator.validatePathV2(result, path, ctx, (result) => success(result as LocalType), failure);
-              } else {
-                success(result as LocalType);
-              }
-            }, 
-            failure);
-        } else if (this.localNextValidator) {
-          this.localNextValidator.validatePathV2(convertedObject, path, ctx, (result) => success(result as LocalType), failure);
         } else {
           success(convertedObject as LocalType);
         }
@@ -241,21 +260,8 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
       }
     }
   }
-
-  omit<T, K extends keyof (any & (InheritableType | LocalType))>(...keys: K[]) {
-    return new ObjectValidator<Omit<LocalType, K extends keyof LocalType ? K : never>, Omit<InheritableType, K extends keyof InheritableType ? K : never>>({
-      properties: pick(this.properties, key => !keys.includes(key as any)),
-      localProperties: pick(this.localProperties, key => !keys.includes(key as any)),
-    });
-  }
-
-  pick<T, K extends keyof (any & (InheritableType | LocalType))>(...keys: K[]) {
-    return new ObjectValidator<Pick<LocalType, K extends keyof LocalType ? K : never>, Pick<InheritableType, K extends keyof InheritableType ? K : never>>({
-      properties: pick(this.properties, key => keys.includes(key as any)),
-      localProperties: pick(this.localProperties, key => keys.includes(key as any)),
-    });
-  }
 }
+
 
 function pick(properties: Properties, fn: (key: keyof any) => boolean): Properties {
   return Object.entries(properties).reduce((current: Properties, [key, validator]) => {

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -1,21 +1,21 @@
 import { Path } from "@finnair/path";
-import { 
-  AnyValidator, 
-  CompositionParameters, 
-  defaultViolations, 
-  FailureCallback, 
-  HasValueValidator, 
-  isNullOrUndefined, 
-  isNumber, 
-  isString, 
-  maybeAllOfValidator, 
-  maybeCompositionOf, 
-  SuccessCallback, 
-  ValidationContext, 
-  Validator, 
-  ValidatorFnWrapperV2, 
+import {
+  AnyValidator,
+  CompositionParameters,
+  defaultViolations,
+  FailureCallback,
+  HasValueValidator,
+  isNullOrUndefined,
+  isNumber,
+  isString,
+  maybeAllOfValidator,
+  maybeCompositionOf,
+  SuccessCallback,
+  ValidationContext,
+  Validator,
+  ValidatorFnWrapperV2,
   Violation,
-  violationsOf, 
+  violationsOf,
 } from "./validators";
 
 export type PropertyModel = { [s: string]: string | number | Validator };
@@ -188,22 +188,22 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
       }
       reportResult();
     };
-    
+
     const reportFailure = (key: string, error: any) => {
       delete convertedObject[key];
       violations = violations.concat(violationsOf(error, path.property(key)));
       reportResult();
     };
-    
+
     const validateLocalProperty = (key: string, propertyValue: unknown, propertyPath: Path) => {
-      this.localProperties[key].validatePathV2(propertyValue, propertyPath, ctx, 
+      this.localProperties[key].validatePathV2(propertyValue, propertyPath, ctx,
         (result) => reportSuccess(key, result),
         (error) => reportFailure(key, error)
       )
     };
 
     const validateProperty = (key: string, propertyValue: unknown, propertyPath: Path) => {
-      this.properties[key].validatePathV2(propertyValue, propertyPath, ctx, 
+      this.properties[key].validatePathV2(propertyValue, propertyPath, ctx,
         (result) => {
           if (this.localProperties[key]) {
             validateLocalProperty(key, propertyValue, propertyPath);
@@ -218,7 +218,7 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
     const validateAdditionalProperty = (key: string, propertyValue: unknown, propertyPath: Path, index: number, keySuccessCount: number, keyError?: Violation[]) => {
       if (index < this.additionalProperties.length) {
         const { keyValidator, valueValidator } = this.additionalProperties[index];
-        keyValidator.validatePathV2(key, propertyPath, ctx, 
+        keyValidator.validatePathV2(key, propertyPath, ctx,
           () => {
             valueValidator.validatePathV2(propertyValue, propertyPath, ctx,
               (result) => validateAdditionalProperty(key, result, propertyPath, index + 1, keySuccessCount + 1),
@@ -354,7 +354,7 @@ function getMapEntryValidators(additionalProperties?: boolean | MapEntryModel | 
 export const lenientUnknownPropertyValidator = new ValidatorFnWrapperV2((value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<any>, failure: FailureCallback) =>
   ctx.failureV2(defaultViolations.unknownProperty(path), value, success, failure));
 
-export const strictUnknownPropertyValidator = new ValidatorFnWrapperV2((value: any, path: Path, ctx: ValidationContext, _success: SuccessCallback<any>, failure: FailureCallback) => 
+export const strictUnknownPropertyValidator = new ValidatorFnWrapperV2((value: any, path: Path, ctx: ValidationContext, _success: SuccessCallback<any>, failure: FailureCallback) =>
   failure([defaultViolations.unknownPropertyDenied(path)]));
 
 const allowAllMapEntries: MapEntryValidator = new MapEntryValidator({

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -123,10 +123,6 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback): void {
-    this.validateFilteredPath(value, path, ctx, success, failure, _ => true);
-  }
-
-  validateFilteredPath(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback, filter: PropertyFilter) {
     if (value === null || value === undefined) {
       failure([defaultViolations.notNull(path)]);
       return;
@@ -233,10 +229,6 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
 
     for (const key of keys) {
       convertedObject[key] = undefined;
-      if (!filter(key)) {
-        reportSuccess(key, undefined);
-        continue;
-      }
       const valuePath = path.property(key);
       const propertyValue = anyValue[key];
       try {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -361,7 +361,7 @@ export class ValidatorFnWrapper<Out = unknown, In = unknown> extends Validator<O
       if (isPromise(maybePromise)) {
         maybePromise.then(
           success,
-          error => ctx.failureV2(error, value, success, failure)
+          error => ctx.failureV2(violationsOf(error, path), value, success, failure)
         );
       } else {
         success(maybePromise);

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -118,8 +118,18 @@ export abstract class Validator<Out = unknown, In = unknown> {
     });
   }
 
+  /**
+   * Validate value and call success callback with valid/converted value or failure callback with Violation[].
+   * 
+   * NOTE: Default implementation calls validatePath() for backwards compatibility. Subclasses should override this to provide a more efficient implementation.
+   * 
+   * @param value 
+   * @param path 
+   * @param ctx 
+   * @param success 
+   * @param failure 
+   */
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
-    // Default implementation for backwards compatibility. Subclasses should override this to provide a more efficient implementation.
     this.validatePath(value, path, ctx).then(
       success,
       (error) => {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -110,8 +110,8 @@ export abstract class Validator<Out = unknown, In = unknown> {
   */
   validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
     return new Promise((resolve: (value: Out) => void, reject: (violations: Violation[]) => void) => {
-      this.validatePathV2(value, path, ctx, 
-        resolve, 
+      this.validatePathV2(value, path, ctx,
+        resolve,
         (error) => {
           reject(violationsOf(error, path));
         });
@@ -380,8 +380,8 @@ export class ValidatorFnWrapperV2<Out = unknown, In = unknown> extends Validator
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     try {
-      this.fn(value, path, ctx, 
-        success, 
+      this.fn(value, path, ctx,
+        success,
         error => ctx.failureV2(error, value, success, failure));
     } catch (error) {
       ctx.failureV2(violationsOf(error, path), value, success, failure);
@@ -423,7 +423,7 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
       const item = value[i];
       const itemPath = path.index(i);
       try {
-        this.itemsValidator.validatePathV2(item, itemPath, ctx, 
+        this.itemsValidator.validatePathV2(item, itemPath, ctx,
           (convertedItem) => {
             convertedArray[i] = convertedItem;
             reportResult();
@@ -502,14 +502,8 @@ export class OneOfValidator<Out = unknown> extends Validator<Out> {
     let newValue: any = null;
     const results: OneOfResult[] = [];
 
-    const reportResults = () => {
-      if (matches === 1) {
-        success(newValue);
-      } else {
-        failure(defaultViolations.oneOf(matches, results, path));
-      }
-    };
-    
+    const reportResults = () => matches === 1 ? success(newValue) : failure(defaultViolations.oneOf(matches, results, path));
+
     const validateNext = (index: number) => {
       if (index < this.validators.length) {
         this.validators[index].validatePathV2(value, path, ctx,
@@ -917,15 +911,15 @@ export class NextStringValidator extends StringValidatorBase<string> {
     Object.freeze(this);
   }
 
-  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void{
-    this.firstValidator.validatePathV2(value, path, ctx, 
-      (firstResult) => this.nextValidator.validatePathV2(firstResult, path, ctx, success, failure), 
+  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
+    this.firstValidator.validatePathV2(value, path, ctx,
+      (firstResult) => this.nextValidator.validatePathV2(firstResult, path, ctx, success, failure),
       failure);
   }
 }
 
 export class StringValidator extends StringValidatorBase<string> {
-  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void{
+  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
       failure([defaultViolations.notNull(path)]);
     } else if (isString(value)) {
@@ -937,7 +931,7 @@ export class StringValidator extends StringValidatorBase<string> {
 }
 
 export class StringNormalizer extends StringValidatorBase<unknown> {
-  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void{
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
       failure([defaultViolations.notNull(path)]);
     } else if (isString(value)) {
@@ -1150,8 +1144,8 @@ export class NextNumberValidator<In> extends NumberValidatorBase<In> {
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
-    this.firstValidator.validatePathV2(value, path, ctx, 
-      (firstResult) => this.nextValidator.validatePathV2(firstResult, path, ctx, success, failure), 
+    this.firstValidator.validatePathV2(value, path, ctx,
+      (firstResult) => this.nextValidator.validatePathV2(firstResult, path, ctx, success, failure),
       failure);
   }
 }
@@ -1260,7 +1254,7 @@ export class EnumValidator<Out extends Record<string, string | number>> extends 
   validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<Out[keyof Out]>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
       return failure([defaultViolations.notNull(path)]);
-    } 
+    }
     if (typeof value === 'string' || typeof value === 'number') {
       const isValid = Object.values(this.enumType).includes(value);
       if (isValid) {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -74,7 +74,9 @@ export abstract class Validator<Out = unknown, In = unknown> {
   */
   async getValid(value: In, options?: ValidatorOptions): Promise<Out> {
     try {
-      return await this.validatePath(value, ROOT, new ValidationContext(options || {}));
+      return await new Promise((resolve: (value: Out) => void, reject: (violations: Violation[]) => void) => {
+        this.validatePathV2(value, ROOT, new ValidationContext(options || {}), resolve, reject);
+      });
     } catch (error) {
       throw new ValidationError(violationsOf(error, ROOT));
     }
@@ -103,25 +105,22 @@ export abstract class Validator<Out = unknown, In = unknown> {
   * @param value 
   * @param path 
   * @param ctx 
+  * @deprecated Use validatePathV2() instead for better performance and less memory usage.
   */
   validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
     return new Promise((resolve: (value: Out) => void, reject: (violations: Violation[]) => void) => {
       this.validatePathV2(value, path, ctx, 
-        (result) => {
-          resolve(result);
-        }, 
-        (violations) => {
-          reject(violations);
+        resolve, 
+        (error) => {
+          reject(violationsOf(error, path));
         });
     });
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
-    // Default implementation for backwards compatibility. Subclasses can override this to provide a more efficient implementation.
+    // Default implementation for backwards compatibility. Subclasses should override this to provide a more efficient implementation.
     this.validatePath(value, path, ctx).then(
-      (result) => {
-        success(result);
-      },
+      success,
       (error) => {
         failure(violationsOf(error, path));
       }
@@ -430,6 +429,7 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
           });
       } catch (error) {
         violations = violations.concat(violationsOf(error, itemPath));
+        reportResult();
       }
     }
   }
@@ -456,10 +456,8 @@ export class CheckValidator<In> extends Validator<In, In> {
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<In> {
-    return this.validator.validatePath(value, path, ctx).then(() => {
-      return value;
-    });
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<In>, failure: FailureCallback): void {
+    return this.validator.validatePathV2(value, path, ctx, () => success(value), failure);
   }
 }
 
@@ -472,12 +470,18 @@ export class CompositionValidator<Out = unknown, In = any> extends Validator<Out
     Object.freeze(this);
   }
 
-  async validatePath(value: In, path: Path, ctx: ValidationContext): Promise<Out> {
-    let currentValue: any = value;
-    for (let i = 0; i < this.validators.length; i++) {
-      currentValue = await this.validators[i].validatePath(currentValue, path, ctx);
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    const validateNext = (index: number, currentValue: any) => {
+      if (index < this.validators.length) {
+        this.validators[index].validatePathV2(currentValue, path, ctx,
+          (result) => validateNext(index + 1, result),
+          (error) => failure(violationsOf(error, path))
+        );
+      } else {
+        success(currentValue);
+      }
     }
-    return Promise.resolve(currentValue);
+    validateNext(0, value);
   }
 }
 
@@ -488,28 +492,38 @@ export class OneOfValidator<Out = unknown> extends Validator<Out> {
     Object.freeze(this);
   }
 
-  async validatePath(value: unknown, path: Path, ctx: ValidationContext): Promise<Out> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     let matches = 0;
     let newValue: any = null;
-    const promises: PromiseLike<OneOfResult>[] = [];
-    for (let i = 0; i < this.validators.length; i++) {
-      promises[i] = this.validators[i].validatePath(value, path, ctx).then(
-        (result) => {
-          matches++;
-          newValue = result;
-          return { success: true };
-        },
-        (error) => {
-          return { violations: violationsOf(error, path) };
-        }
-      );
-    }
-    // Promise handler takes care of error handling, so Promise.all is safe
-    const results = await Promise.all(promises);
-    if (matches === 1) {
-      return Promise.resolve(newValue);
-    }
-    return Promise.reject(defaultViolations.oneOf(matches, results, path));
+    const results: OneOfResult[] = [];
+
+    const reportResults = () => {
+      if (matches === 1) {
+        success(newValue);
+      } else {
+        failure(defaultViolations.oneOf(matches, results, path));
+      }
+    };
+    
+    const validateNext = (index: number) => {
+      if (index < this.validators.length) {
+        this.validators[index].validatePathV2(value, path, ctx,
+          (result) => {
+            matches++;
+            newValue = result;
+            results.push({ success: true });
+            validateNext(index + 1);
+          },
+          (error) => {
+            results.push({ violations: violationsOf(error, path) });
+            validateNext(index + 1);
+          }
+        );
+      } else {
+        reportResults();
+      }
+    };
+    validateNext(0);
   }
 }
 
@@ -519,28 +533,22 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
     Object.freeze(this.validators);
     Object.freeze(this);
   }
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
-    let passes: Out[] = [];
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     let violations: Violation[] = [];
-    const promises = [] as PromiseLike<void>[];
-    for (const validator of this.validators) {
-      promises.push(
-        validator.validatePath(value, path, ctx).then(
-          (result) => {
-            passes.push(result);
-          },
+    const validateNext = (index: number) => {
+      if (index < this.validators.length) {
+        this.validators[index].validatePathV2(value, path, ctx,
+          success,
           (error) => {
             violations = violations.concat(violationsOf(error, path));
+            validateNext(index + 1);
           }
-        )
-      );
-    }
-    return Promise.allSettled(promises).then(() => {
-      if (passes.length > 0) {
-        return Promise.resolve(passes[passes.length - 1]);
+        );
+      } else {
+        failure(violations);
       }
-      return Promise.reject(violations);
-    })
+    }
+    validateNext(0);
   }
 }
 
@@ -554,17 +562,19 @@ export class IfValidator<If = unknown, In = unknown, Else = unknown> extends Val
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<If | Else> {
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<If | Else>, failure: FailureCallback): void {
     for (let i = 0; i < this.conditionals.length; i++) {
       const conditional = this.conditionals[i];
       if (conditional.fn(value, path, ctx)) {
-        return conditional.validator.validatePath(value, path, ctx);
+        conditional.validator.validatePathV2(value, path, ctx, success, failure);
+        return;
       }
     }
     if (this.elseValidator) {
-      return this.elseValidator.validatePath(value, path, ctx);
+      this.elseValidator.validatePathV2(value, path, ctx, success, failure);
+      return;
     }
-    return Promise.reject(new Violation(path, 'NoMatchingCondition', value));
+    failure(new Violation(path, 'NoMatchingCondition', value));
   }
 
   elseIf<ElIf, ElIn>(fn: AssertTrue, validator: Validator<ElIf, ElIn>): IfValidator<If | ElIf, In | ElIn, Else> {
@@ -599,37 +609,47 @@ export class WhenGroupValidator<When = unknown, Otherwise = unknown, In = unknow
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<When | Otherwise> {
-    if (ctx.options.group) {
-      let passes: When[] = [];
-      let violations: Violation[] = [];
-      const promises = [] as PromiseLike<void>[];
-      for (let i = 0; i < this.whenGroups.length; i++) {
-        const whenGroup = this.whenGroups[i];
-        if (ctx.options.group.includes(whenGroup.group)) {
-          promises.push(whenGroup.validator.validatePath(value, path, ctx).then(
-            (result) => {
-              passes.push(result);
-            },
-            (error) => {
-              violations = violations.concat(violationsOf(error, path));
-            }
-          ));
-        }
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<When | Otherwise>, failure: FailureCallback): void {
+    const group = ctx.options?.group;
+    let groupMatches = 0;
+    let violations: Violation[] = [];
+    const report = (currentValue?: any) => {
+      if (violations.length > 0) {
+        failure(violations);
+      } else if (groupMatches > 0) {
+        success(currentValue);
+      } else if (this.otherwiseValidator) {
+        this.otherwiseValidator.validatePathV2(value, path, ctx, success, failure);
+      } else {
+        failure([new Violation(path, 'NoMatchingGroup', value)]);
       }
-      if (promises.length) {
-        return Promise.allSettled(promises).then(() => {
-          if (violations.length > 0) {
-            return Promise.reject(violations);
+    }
+    if (group) {
+      const validateNext = (index: number, currentValue: any) => {
+        if (index < this.whenGroups.length) {
+          const whenGroup = this.whenGroups[index];
+          if (group.includes(whenGroup.group)) {
+            groupMatches++;
+            whenGroup.validator.validatePathV2(value, path, ctx,
+              (result) => {
+                validateNext(index + 1, result);
+              },
+              (error) => {
+                violations = violations.concat(violationsOf(error, path));
+                validateNext(index + 1, currentValue);
+              }
+            );
+          } else {
+            validateNext(index + 1, currentValue);
           }
-          return passes[passes.length - 1];
-        });
-      }
+        } else {
+          report(currentValue);
+        }
+      };
+      validateNext(0, value);
+    } else {
+      report(value);
     }
-    if (this.otherwiseValidator) {
-      return this.otherwiseValidator.validatePath(value, path, ctx);
-    }
-    return Promise.reject(new Violation(path, 'NoMatchingGroup', value));
   }
 
   whenGroup<W = unknown>(group: GroupOrName, validator: Validator<W>): WhenGroupValidator<When | W, Otherwise> {
@@ -664,47 +684,63 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
     super();
     Object.freeze(this);
   }
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<E extends true ? JsonMap<K, V> : Map<K, V>> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<E extends true ? JsonMap<K, V> : Map<K, V>>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if (!(value instanceof Map)) {
-      return Promise.reject(new TypeMismatch(path, 'Map'));
+      return failure(new TypeMismatch(path, 'Map'));
     }
     const map: Map<any, any> = value as Map<any, any>;
-    const convertedMap = this.jsonSafeMap ? new JsonMap<K, V>() : new Map<K, V>();
-    const promises: Promise<void>[] = [];
     let violations: Violation[] = [];
-    let i = 0;
-    for (const [key, value] of map) {
-      const entryPath = path.index(i);
-      const keyPath = entryPath.index(0);
-      const valuePath = entryPath.index(1);
-      const keyPromise = this.keys.validatePath(key, keyPath, ctx);
-      const valuePromise = this.values.validatePath(value, valuePath, ctx);
-      promises[i] = Promise.allSettled([keyPromise, valuePromise]).then(results => {
-        const keyResult = results[0];
-        const valueResult = results[1];
-        if (keyResult.status === 'fulfilled' && valueResult.status === 'fulfilled') {
-          convertedMap.set(keyResult.value, valueResult.value);
-        } else {
-          if (keyResult.status === 'rejected') {
-            violations = violations.concat(violationsOf(keyResult.reason, keyPath));
-          }
-          if (valueResult.status === 'rejected') {
-            violations = violations.concat(violationsOf(valueResult.reason, valuePath));
-          }
-        }
-      });
-      ++i;
+    const entries: [K, V][] = [];
+    let expectedResponses = map.size * 2;
+
+    const reportResult = () => {
+      if (violations.length > 0) {
+        failure(violations);
+      } else {
+        success(this.jsonSafeMap ? new JsonMap<K, V>(entries) : new Map<K, V>(entries) as any);
+      }
     }
 
-    return Promise.allSettled(promises).then(_ => {
-      if (violations.length > 0) {
-        return Promise.reject(violations);
+    if (map.size === 0) {
+      reportResult();
+    }
+
+    const reportEntry = (entryIndex: number, keyOrValue: 0 | 1, value: undefined | any, error: undefined | any) => {
+      if (error) {
+        violations = violations.concat(violationsOf(error, path.index(entryIndex).index(keyOrValue)));
+      } else {
+        entries[entryIndex] = entries[entryIndex] ?? [];
+        entries[entryIndex][keyOrValue] = value;
       }
-      return Promise.resolve(convertedMap as any);
-    });
+      if (--expectedResponses === 0) {
+        reportResult();
+      }
+    };
+
+    let i = 0;
+    for (const [key, value] of map) {
+      const entryIndex = i++;
+      const entryPath = path.index(entryIndex);
+      try {
+        this.keys.validatePathV2(key, entryPath.index(0), ctx,
+          (result) => reportEntry(entryIndex, 0, result, undefined),
+          (error) => reportEntry(entryIndex, 0, undefined, error)
+        );
+      } catch (error) {
+        reportEntry(entryIndex, 0, undefined, error);
+      }
+      try {
+        this.values.validatePathV2(value, entryPath.index(1), ctx,
+          (result) => reportEntry(entryIndex, 1, result, undefined),
+          (error) => reportEntry(entryIndex, 1, undefined, error)
+        );
+      } catch (error) {
+        reportEntry(entryIndex, 1, undefined, error);
+      }
+    }
   }
 }
 
@@ -712,9 +748,9 @@ export class MapNormalizer<K = unknown, V = unknown, E extends boolean = true> e
   constructor(keys: Validator<K>, values: Validator<V>, jsonSafeMap: E) {
     super(keys, values, jsonSafeMap);
   }
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<E extends true ? JsonMap<K, V> : Map<K, V>> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<E extends true ? JsonMap<K, V> : Map<K, V>>, failure: FailureCallback): void {
     if (value instanceof Map) {
-      return super.validatePath(value, path, ctx);
+      return super.validatePathV2(value, path, ctx, success, failure);
     }
     if (Array.isArray(value)) {
       let violations: Violation[] = [];
@@ -732,11 +768,13 @@ export class MapNormalizer<K = unknown, V = unknown, E extends boolean = true> e
         }
       }
       if (violations.length > 0) {
-        return Promise.reject(violations);
+        failure(violations);
+        return;
       }
-      return super.validatePath(map, path, ctx);
+      super.validatePathV2(map, path, ctx, success, failure);
+      return; 
     }
-    return Promise.reject(new TypeMismatch(path, 'Map OR array of [key, value] arrays'));
+    failure(new TypeMismatch(path, 'Map OR array of [key, value] arrays'));
   }
 }
 
@@ -754,36 +792,49 @@ export class SetValidator<T = unknown, E extends boolean = true> extends Validat
     super();
     Object.freeze(this);
   }
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<E extends true ? JsonSet<T> : Set<T>> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<E extends true ? JsonSet<T> : Set<T>>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure([defaultViolations.notNull(path)]);
     }
     if (!(value instanceof Set || Array.isArray(value))) {
-      return Promise.reject(new TypeMismatch(path, 'Set'));
-    }
-    const convertedSet = this.jsonSafeSet ? new JsonSet<T>() : new Set<T>();
-    const promises: PromiseLike<void>[] = [];
-    let violations: Violation[] = [];
-    let i = 0;
-    for (const entry of value) {
-      const entryPath = path.index(i);
-      promises[i] = this.values.validatePath(entry, entryPath, ctx).then(
-        (result) => {
-          convertedSet.add(result);
-        },
-        (error) => {
-          violations = violations.concat(violationsOf(error,  entryPath));
-        }
-      );
-      ++i;
+      return failure(new TypeMismatch(path, 'Set'));
     }
 
-    return Promise.allSettled(promises).then(_ => {
+    const items: T[] = [];
+    let violations: Violation[] = [];
+    let expectedResponses = (value instanceof Set ? value.size : value.length);
+
+    const reportResult = () => {
       if (violations.length > 0) {
-        return Promise.reject(violations);
+        failure(violations);
+      } else {
+        success(this.jsonSafeSet ? new JsonSet<T>(items) : new Set<T>(items) as any);
       }
-      return Promise.resolve(convertedSet as any);
-    });
+    };
+
+    if (expectedResponses === 0) {
+      return reportResult();
+    }
+
+    const reportItem = (index: number, item: any, error: any) => {
+      if (error) {
+        violations = violations.concat(violationsOf(error, path.index(index)));
+      } else {
+        items[index] = item;
+      }
+      if (--expectedResponses === 0) {
+        reportResult();
+      }
+    };
+
+    let i = 0;
+    for (const entry of value) {
+      const index = i++
+      this.values.validatePathV2(entry, path.index(index), ctx,
+        (result) => reportItem(index, result, undefined),
+        (error) => reportItem(index, undefined, error)
+      );
+    }
   }
 }
 
@@ -820,14 +871,14 @@ export class JsonBigInt {
 }
 
 export class AnyValidator<InOut = any> extends Validator<InOut> {
-  validatePath(value: InOut, path: Path, ctx: ValidationContext): PromiseLike<InOut> {
-    return Promise.resolve(value);
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<InOut>, failure: FailureCallback): void {
+    success(value as InOut);
   }
 }
 
 export class UnknownValidator<InOut = unknown> extends Validator<InOut> {
-  validatePath(value: InOut, path: Path, ctx: ValidationContext): PromiseLike<InOut> {
-    return Promise.resolve(value);
+  validatePathV2(value: InOut, path: Path, ctx: ValidationContext, success: SuccessCallback<InOut>, failure: FailureCallback): void {
+    success(value);
   }
 }
 
@@ -900,34 +951,33 @@ export class StringNormalizer extends StringValidatorBase<unknown> {
   }
 }
 
-export class NotNullOrUndefinedValidator<InOut> extends Validator<
-  InOut extends null ? never : InOut extends undefined ? never : InOut,
-  InOut extends null ? never : InOut extends undefined ? never : InOut
-> {
-  validatePath(value: InOut extends null ? never : InOut extends undefined ? never : InOut, path: Path, ctx: ValidationContext):
-    PromiseLike<InOut extends null ? never : InOut extends undefined ? never : InOut> {
+export class NotNullOrUndefinedValidator<InOut> extends Validator<Exclude<InOut, null | undefined>, InOut> {
+  validatePathV2(value: InOut, path: Path, ctx: ValidationContext, success: SuccessCallback<Exclude<InOut, null | undefined>>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure([defaultViolations.notNull(path)]);
+    } else {
+      success(value as any);
     }
-    return Promise.resolve(value);
   }
 }
 
 export class IsNullOrUndefinedValidator extends Validator<null | undefined> {
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<null | undefined> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<null | undefined>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.resolve(value);
+      success(value);
+    } else {
+      failure([new TypeMismatch(path, 'NullOrUndefined', value)]);
     }
-    return Promise.reject(new TypeMismatch(path, 'NullOrUndefined', value));
   }
 }
 
 export class NotEmptyValidator<InOut extends { length: number }> extends Validator<InOut, InOut> {
-  validatePath(value: InOut, path: Path, ctx: ValidationContext): PromiseLike<InOut> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<InOut>, failure: FailureCallback): void {
     if (!isNullOrUndefined(value) && isNumber((value as any).length) && (value as any).length > 0) {
-      return Promise.resolve(value);
+      success(value as InOut);
+    } else {
+      failure([defaultViolations.notEmpty(path)]);
     }
-    return Promise.reject(defaultViolations.notEmpty(path));
   }
 }
 
@@ -940,33 +990,33 @@ export class SizeValidator<InOut extends { length: number }> extends Validator<I
     Object.freeze(this);
   }
 
-  validatePath(value: InOut, path: Path, ctx: ValidationContext): PromiseLike<InOut> {
+  validatePathV2(value: InOut, path: Path, ctx: ValidationContext, success: SuccessCallback<InOut>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure([defaultViolations.notNull(path)]);
+    } else if (!isNumber(value.length)) {
+      failure([new TypeMismatch(path, 'value with numeric length field', value)]);
+    } else if (value.length < this.min || value.length > this.max) {
+      failure([defaultViolations.size(this.min, this.max, path)]);
+    } else {
+      success(value);
     }
-    if (!isNumber(value.length)) {
-      return Promise.reject(new TypeMismatch(path, 'value with numeric length field'));
-    }
-    if (value.length < this.min || value.length > this.max) {
-      return Promise.reject(defaultViolations.size(this.min, this.max, path));
-    }
-    return Promise.resolve(value);
   }
 }
 
 export class NotBlankValidator extends Validator<string, string> {
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<string> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notBlank(path));
+      failure([defaultViolations.notBlank(path)]);
+    } else if (!isString(value)) {
+      failure([defaultViolations.string(value, path)]);
+    } else {
+      const trimmed = (value as string).trim();
+      if (trimmed === '') {
+        failure([defaultViolations.notBlank(path)]);
+      } else {
+        success(value as string);
+      }
     }
-    if (!isString(value)) {
-      return Promise.reject(defaultViolations.string(value, path));
-    }
-    const trimmed = (value as String).trim();
-    if (trimmed === '') {
-      return Promise.reject(defaultViolations.notBlank(path));
-    }
-    return Promise.resolve(value);
   }
 }
 
@@ -990,28 +1040,26 @@ export class BooleanNormalizer extends Validator<boolean> {
     Object.freeze(this);
   }
 
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<boolean> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<boolean>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
-    }
-    if (typeof value === 'boolean') {
-      return Promise.resolve(value);
-    }
-    if (value instanceof Boolean) {
-      return Promise.resolve(value.valueOf());
-    }
-    if (isString(value)) {
+      failure([defaultViolations.notNull(path)]);
+    } else if (typeof value === 'boolean') {
+      success(value);
+    } else if (value instanceof Boolean) {
+      success(value.valueOf());
+    } else if (isString(value)) {
       if (this.truePattern.test(value)) {
-        return Promise.resolve(true);
+        success(true);
+      } else if (this.falsePattern.test(value)) {
+        success(false);
+      } else {
+        failure([defaultViolations.boolean(value, path)]);
       }
-      if (this.falsePattern.test(value)) {
-        return Promise.resolve(false);
-      }
-      return Promise.reject(defaultViolations.boolean(value, path));
     } else if (isNumber(value)) {
-      return Promise.resolve(!!value);
+      success(!!value);
+    } else {
+      failure([defaultViolations.boolean(value, path)]);
     }
-    return Promise.reject(defaultViolations.boolean(value, path));
   }
 }
 
@@ -1068,30 +1116,30 @@ export class JsonBigIntValidator extends Validator<JsonBigInt, any> {
     super();
     Object.freeze(this);
   }
-  validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<JsonBigInt> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<JsonBigInt>, failure: FailureCallback): void {
     const valueType = typeof value;
     switch (valueType) {
       case 'bigint':
-        return Promise.resolve(new JsonBigInt(value));
+        return success(new JsonBigInt(value));
       case 'number':
         try {
-          return Promise.resolve(new JsonBigInt(BigInt(value)));
+          return success(new JsonBigInt(BigInt(value)));
         } catch (e) {
-          return Promise.reject(new TypeMismatch(path, 'integer', value));
+          return failure(new TypeMismatch(path, 'integer', value));
         }
       case 'string':
         if (value.match(bigIntFormat)) {
-          return Promise.resolve(new JsonBigInt(BigInt(value)));
+          return success(new JsonBigInt(BigInt(value)));
         } else {
-          return Promise.reject(new TypeMismatch(path, bigIntFormat.toString(), value));
+          return failure(new TypeMismatch(path, bigIntFormat.toString(), value));
         }
       case 'object':
         if (value instanceof JsonBigInt) {
-          return Promise.resolve(value);
+          return success(value);
         }
         break;
     }
-    return Promise.reject(new TypeMismatch(path, 'JsonBigInt, bigint or integer as number or string', value));
+    return failure(new TypeMismatch(path, 'JsonBigInt, bigint or integer as number or string', value));
   }
 }
 
@@ -1161,21 +1209,21 @@ export class MinValidator extends Validator<number, number> {
     Object.freeze(this);
   }
 
-  validatePath(value: number, path: Path, ctx: ValidationContext): PromiseLike<number> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if (!isNumber(value)) {
-      return Promise.reject(defaultViolations.number(value, NumberFormat.number, path));
+      return failure(defaultViolations.number(value, NumberFormat.number, path));
     }
     if (this.inclusive) {
       if (value < this.min) {
-        return Promise.reject(defaultViolations.min(this.min, this.inclusive, value, path));
+        return failure(defaultViolations.min(this.min, this.inclusive, value, path));
       }
     } else if (value <= this.min) {
-      return Promise.reject(defaultViolations.min(this.min, this.inclusive, value, path));
+      return failure(defaultViolations.min(this.min, this.inclusive, value, path));
     }
-    return Promise.resolve(value);
+    return success(value);
   }
 }
 
@@ -1185,21 +1233,21 @@ export class MaxValidator extends Validator<number, number> {
     Object.freeze(this);
   }
 
-  validatePath(value: number, path: Path, ctx: ValidationContext): PromiseLike<number> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if (!isNumber(value)) {
-      return Promise.reject(defaultViolations.number(value, NumberFormat.number, path));
+      return failure(defaultViolations.number(value, NumberFormat.number, path));
     }
     if (this.inclusive) {
       if (value > this.max) {
-        return Promise.reject(defaultViolations.max(this.max, this.inclusive, value, path));
+        return failure(defaultViolations.max(this.max, this.inclusive, value, path));
       }
     } else if (value >= this.max) {
-      return Promise.reject(defaultViolations.max(this.max, this.inclusive, value, path));
+      return failure(defaultViolations.max(this.max, this.inclusive, value, path));
     }
-    return Promise.resolve(value);
+    return success(value);
   }
 }
 
@@ -1231,11 +1279,11 @@ export class AssertTrueValidator<In> extends Validator<In, In> {
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<In> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<In>, failure: FailureCallback): void {
     if (!this.fn(value, path, ctx)) {
-      return Promise.reject(new Violation(this.path ? this.path.connectTo(path) : path, this.type));
+      return failure(new Violation(this.path ? this.path.connectTo(path) : path, this.type));
     }
-    return Promise.resolve(value);
+    return success(value);
   }
 }
 
@@ -1243,20 +1291,20 @@ export class UuidValidator extends Validator<string> {
   constructor(public readonly version?: number) {
     super();
   }
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<string> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if (!isString(value)) {
-      return Promise.reject(defaultViolations.string(value, path));
+      return failure(defaultViolations.string(value, path));
     }
     if (!uuidValidate(value)) {
-      return Promise.reject(new Violation(path, 'UUID', value));
+      return failure(new Violation(path, 'UUID', value));
     }
     if (this.version && uuidVersion(value) !== this.version) {
-      return Promise.reject(new Violation(path, `UUIDv${this.version}`, value));
+      return failure(new Violation(path, `UUIDv${this.version}`, value));
     }
-    return Promise.resolve(value);
+    return success(value);
   }
 }
 
@@ -1265,48 +1313,58 @@ export class HasValueValidator<InOut> extends Validator<InOut> {
     super();
     Object.freeze(this);
   }
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<InOut> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<InOut>, failure: FailureCallback): void {
     if (deepEqual(value, this.expectedValue)) {
-      return Promise.resolve(value as InOut);
+      return success(value as InOut);
     }
-    return Promise.reject(new HasValueViolation(path, this.expectedValue, value));
+    return failure(new HasValueViolation(path, this.expectedValue, value));
   }
 }
 
 export class AllOfValidator<Out, In> extends Validator<Out, In> {
   constructor(public readonly validators: [Validator<Out, In>, ...Validator<Out, In>[]]) {
     super();
+    if (this.validators.length === 0) {
+      throw new Error('AllOfValidator: At least one validator required');
+    }
     Object.freeze(this.validators);
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     let violations: Violation[] = [];
     let firstResult = true;
     let convertedValue: any;
-    const promises: PromiseLike<any>[] = [];
+    let expectedResponses = this.validators.length;
+
+    const reportResult = (result: undefined | Out, error: any) => {
+      if (error) {
+        violations = violations.concat(violationsOf(error, path));
+      } else if (firstResult) {
+        convertedValue = result;
+        firstResult = false;
+      } else if (!deepEqual(result, convertedValue)) {
+        violations.push(new Violation(path, 'ConflictingConversions', value));
+      }
+      if (--expectedResponses === 0) {
+        if (violations.length > 0) {
+          failure(violations);
+        } else {
+          success(convertedValue);
+        }
+      }
+    };
+
     for (let i = 0; i < this.validators.length; i++) {
       const validator = this.validators[i];
-      promises[i] = validator.validatePath(value, path, ctx).then(
-        (result) => {
-          if (firstResult) {
-            convertedValue = result;
-            firstResult = false;
-          } else if (!deepEqual(result, convertedValue)) {
-            violations.push(new Violation(path, 'ConflictingConversions', value));
-          }
-        },
-        (error) => {
-          violations = violations.concat(violationsOf(error, path));
-        }
+      validator.validatePathV2(
+        value,
+        path,
+        ctx,
+        (result) => reportResult(result, undefined),
+        (error) => reportResult(undefined, error)
       );
     }
-    return Promise.allSettled(promises).then(_ => {
-      if (violations.length == 0) {
-        return Promise.resolve(convertedValue);
-      }
-      return Promise.reject(violations);
-    });
   }
 }
 
@@ -1316,9 +1374,9 @@ export class DateValidator extends Validator<Date> {
     Object.freeze(this);
   }
 
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<Date> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Date>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     let dateValue: any;
     if (isString(value) || isNumber(value)) {
@@ -1328,11 +1386,11 @@ export class DateValidator extends Validator<Date> {
     }
     if (dateValue instanceof Date) {
       if (isNaN((dateValue as Date).getTime())) {
-        return Promise.reject(defaultViolations.date(value, path));
+        return failure(defaultViolations.date(value, path));
       }
-      return Promise.resolve(dateValue);
+      return success(dateValue);
     }
-    return Promise.reject(defaultViolations.date(value, path, this.dateType));
+    return failure(defaultViolations.date(value, path, this.dateType));
   }
 }
 
@@ -1346,17 +1404,16 @@ export class PatternValidator extends StringValidatorBase<string> {
     Object.freeze(this);
   }
 
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<string> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure(defaultViolations.notNull(path));
+    } else if (!isString(value)) {
+      failure(defaultViolations.string(value, path));
+    } else if (this.regExp.test(value)) {
+      success(value);
+    } else {
+      failure(defaultViolations.pattern(this.regExp, value, path));
     }
-    if (!isString(value)) {
-      return Promise.reject(defaultViolations.string(value, path));
-    }
-    if (this.regExp.test(value)) {
-      return Promise.resolve(value);
-    }
-    return Promise.reject(defaultViolations.pattern(this.regExp, value, path));
   }
 
   toJSON() {
@@ -1370,17 +1427,16 @@ export class PatternNormalizer extends PatternValidator {
   constructor(pattern: string | RegExp, flags?: string) {
     super(pattern, flags);
   }
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<string> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure(defaultViolations.notNull(path));
+    } else if (isString(value)) {
+      super.validatePathV2(value, path, ctx, success, failure);
+    } else if (isSimplePrimitive(value)) {
+      super.validatePathV2(String(value), path, ctx, success, failure);
+    } else {
+      failure(new TypeMismatch(path, 'primitive value', value));
     }
-    if (isString(value)) {
-      return super.validatePath(value, path, ctx);
-    }
-    if (isSimplePrimitive(value)) {
-      return super.validatePath(String(value), path, ctx);
-    }
-    return Promise.reject(new TypeMismatch(path, 'primitive value', value));
   }
 }
 
@@ -1437,11 +1493,12 @@ export class RequiredValidator<Out, In> extends Validator<Out, In> {
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure(defaultViolations.notNull(path));
+    } else {
+      this.validator.validatePathV2(value, path, ctx, success, failure);
     }
-    return this.validator.validatePath(value, path, ctx);
   }
 }
 
@@ -1481,8 +1538,8 @@ export class IdentityValidator<Out = unknown> extends Validator<Out, Out> {
     super();
     Object.freeze(this);
   }
-  validatePath(value: Out): PromiseLike<Out> {
-    return Promise.resolve(value);
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    success(value);
   }
 }
 
@@ -1491,8 +1548,8 @@ export function isPromise(value: any): value is PromiseLike<any> {
 }
 
 export class IgnoreValidator extends Validator<undefined> {
-  validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<undefined> {
-    return Promise.resolve(undefined);
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined>, failure: FailureCallback): void {
+    return success(undefined);
   }
 }
 
@@ -1502,18 +1559,18 @@ export class JsonValidator<Out> extends Validator<Out, string> {
     Object.freeze(this);
   }
 
-  validatePath(value: string, path: Path, ctx: ValidationContext): PromiseLike<Out> {
+  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if (!isString(value)) {
-      return Promise.reject(defaultViolations.string(value, path));
+      return failure(defaultViolations.string(value, path));
     }
     try {
       const parsedValue = JSON.parse(value);
-      return this.validator.validatePath(parsedValue, path, ctx);
+      this.validator.validatePathV2(parsedValue, path, ctx, success, failure);
     } catch (e) {
-      return Promise.reject(new TypeMismatch(path, 'JSON', value));
+      return failure(new TypeMismatch(path, 'JSON', value));
     }
   }
 }

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -8,6 +8,10 @@ export interface ValidatorFn<Out = unknown, In = unknown> {
   (value: In, path: Path, ctx: ValidationContext): PromiseLike<Out>;
 }
 
+export interface ValidatorFnV2<Out = unknown, In = unknown> {
+  (value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void;
+}
+
 export interface MappingFn<Out = unknown, In = unknown> {
   (value: In, path: Path, ctx: ValidationContext): Out | PromiseLike<Out>;
 }
@@ -26,14 +30,20 @@ export class ValidationContext {
   * Optionally ignore an error for backwards compatible changes (enum values, new properties).
   */
   failure<Out = unknown, In = unknown>(violation: Violation | Violation[], value: In) {
+    return new Promise((resolve, reject) => {
+      this.failureV2<Out, In>(violation, value, resolve, reject);
+    });
+  }
+  failureV2<Out = unknown, In = unknown>(violation: Violation | Violation[], value: In, success: SuccessCallback<Out>, failure: FailureCallback) {
     const violations: Violation[] = ([] as Violation[]).concat(violation);
     if (violations.length === 1 && this.ignoreViolation(violations[0])) {
       if (this.options.warnLogger) {
         this.options.warnLogger(violations[0], this.options);
       }
-      return Promise.resolve(value as unknown as Out);
+      success(value as unknown as Out);
+    } else {
+      failure(violations);
     }
-    return Promise.reject(violations);
   }
   private ignoreViolation(violation: Violation) {
     return (
@@ -41,6 +51,13 @@ export class ValidationContext {
       (this.options.ignoreUnknownProperties && violation.type === ValidatorType.UnknownProperty)
     );
   }
+}
+
+export interface SuccessCallback<Out = unknown> {
+  (value: Out): void;
+}
+export interface FailureCallback {
+  (error: any): void;
 }
 
 export abstract class Validator<Out = unknown, In = unknown> {
@@ -72,7 +89,9 @@ export abstract class Validator<Out = unknown, In = unknown> {
   */
   async validate(value: In, options?: ValidatorOptions): Promise<ValidationResult<Out>> {
     try {
-      const result = await this.validatePath(value, ROOT, new ValidationContext(options || {}));
+      const result = await new Promise((resolve: (value: Out) => void, reject: (violations: Violation[]) => void) => {
+        this.validatePathV2(value, ROOT, new ValidationContext(options || {}), resolve, reject);
+      });
       return new ValidationResult(undefined, result);
     } catch (error) {
       return new ValidationResult<Out>(violationsOf(error, ROOT));
@@ -85,7 +104,29 @@ export abstract class Validator<Out = unknown, In = unknown> {
   * @param path 
   * @param ctx 
   */
-  abstract validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out>;
+  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
+    return new Promise((resolve: (value: Out) => void, reject: (violations: Violation[]) => void) => {
+      this.validatePathV2(value, path, ctx, 
+        (result) => {
+          resolve(result);
+        }, 
+        (violations) => {
+          reject(violations);
+        });
+    });
+  }
+
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    // Default implementation for backwards compatibility. Subclasses can override this to provide a more efficient implementation.
+    this.validatePath(value, path, ctx).then(
+      (result) => {
+        success(result);
+      },
+      (error) => {
+        failure(violationsOf(error, path));
+      }
+    );
+  }
 
   next<NextOut = unknown, T1 = unknown, T2 = unknown, T3 = unknown, T4 = unknown>(...validators: NextCompositionParameters<NextOut, Out, T1, T2, T3, T4>) {
     return maybeCompositionOf(this, ...validators);
@@ -314,8 +355,31 @@ export class ValidatorFnWrapper<Out = unknown, In = unknown> extends Validator<O
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
-    return this.fn(value, path, ctx);
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    try {
+      const maybePromise = this.fn(value, path, ctx);
+      if (isPromise(maybePromise)) {
+        maybePromise.then(
+          success,
+          error => ctx.failureV2(error, value, success, failure)
+        );
+      } else {
+        success(maybePromise);
+      }
+    } catch (error) {
+      ctx.failureV2(violationsOf(error, path), value, success, failure);
+    }
+  }
+}
+
+export class ValidatorFnWrapperV2<Out = unknown, In = unknown> extends Validator<Out, In> {
+  constructor(private readonly fn: ValidatorFnV2<Out, In>, public readonly type?: string) {
+    super();
+    Object.freeze(this);
+  }
+
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    this.fn(value, path, ctx, success, failure);
   }
 }
 
@@ -325,32 +389,49 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
     Object.freeze(this);
   }
 
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<Out[]> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<Out[]>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure([defaultViolations.notNull(path)]);
+      return;
     }
     if (!Array.isArray(value)) {
-      return Promise.reject(new TypeMismatch(path, 'array', value));
+      failure([new TypeMismatch(path, 'array', value)]);
+      return;
     }
-    const convertedArray: Array<any> = [];
-
-    const promises: PromiseLike<any>[] = [];
+    const convertedArray: Out[] = [];
+    if (value.length === 0) {
+      return success(convertedArray);
+    }
+    let expectedResponses = value.length;
     let violations: Violation[] = [];
+
+    const reportResult = () => {
+      if (--expectedResponses === 0) {
+        if (violations.length > 0) {
+          failure(violations);
+        } else {
+          success(convertedArray);
+        }
+      }
+    };
+
     for (let i = 0; i < value.length; i++) {
       const item = value[i];
       const itemPath = path.index(i);
-      promises[i] = this.itemsValidator.validatePath(item, itemPath, ctx).then(
-        (result) => convertedArray[i] = result,
-        (reject) => violations = violations.concat(violationsOf(reject, itemPath))
-      );
-    }
-
-    return Promise.allSettled(promises).then(_ => {
-      if (violations.length === 0) {
-        return Promise.resolve(convertedArray);
+      try {
+        this.itemsValidator.validatePathV2(item, itemPath, ctx, 
+          (convertedItem) => {
+            convertedArray[i] = convertedItem;
+            reportResult();
+          },
+          (error) => {
+            violations = violations.concat(error);
+            reportResult();
+          });
+      } catch (error) {
+        violations = violations.concat(violationsOf(error, itemPath));
       }
-      return Promise.reject(violations);
-    });
+    }
   }
 }
 
@@ -358,14 +439,14 @@ export class ArrayNormalizer<T> extends ArrayValidator<T> {
   constructor(itemsValidator: Validator<T>) {
     super(itemsValidator);
   }
-  validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<T[]> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<T[]>, failure: FailureCallback) {
     if (value === undefined) {
-      return super.validatePath([], path, ctx);
+      return super.validatePathV2([], path, ctx, success, failure);
     }
     if (Array.isArray(value)) {
-      return super.validatePath(value, path, ctx);
+      return super.validatePathV2(value, path, ctx, success, failure);
     }
-    return super.validatePath([value], path, ctx);
+    return super.validatePathV2([value], path, ctx, success, failure);
   }
 }
 
@@ -784,38 +865,38 @@ export class NextStringValidator extends StringValidatorBase<string> {
     Object.freeze(this);
   }
 
-  validatePath(value: string, path: Path, ctx: ValidationContext): PromiseLike<string> {
-    return this.firstValidator.validatePath(value, path, ctx).then(firstResult => this.nextValidator.validatePath(firstResult, path, ctx));
+  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void{
+    this.firstValidator.validatePathV2(value, path, ctx, 
+      (firstResult) => this.nextValidator.validatePathV2(firstResult, path, ctx, success, failure), 
+      failure);
   }
 }
 
 export class StringValidator extends StringValidatorBase<string> {
-  validatePath(value: string, path: Path, ctx: ValidationContext): PromiseLike<string> {
+  validatePathV2(value: string, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void{
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure([defaultViolations.notNull(path)]);
+    } else if (isString(value)) {
+      success(value);
+    } else {
+      failure([defaultViolations.string(value, path)]);
     }
-    if (isString(value)) {
-      return Promise.resolve(value);
-    }
-    return Promise.reject(defaultViolations.string(value, path));
   }
 }
 
 export class StringNormalizer extends StringValidatorBase<unknown> {
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<string> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<string>, failure: FailureCallback): void{
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure([defaultViolations.notNull(path)]);
+    } else if (isString(value)) {
+      success(value);
+    } else if (value instanceof String) {
+      success(value.valueOf());
+    } else if (isSimplePrimitive(value)) {
+      success(String(value));
+    } else {
+      failure([new TypeMismatch(path, 'primitive value', value)]);
     }
-    if (isString(value)) {
-      return Promise.resolve(value);
-    }
-    if (value instanceof String) {
-      return Promise.resolve(value.valueOf());
-    }
-    if (isSimplePrimitive(value)) {
-      return Promise.resolve(String(value));
-    }
-    return Promise.reject(new TypeMismatch(path, 'primitive value', value));
   }
 }
 
@@ -890,14 +971,14 @@ export class NotBlankValidator extends Validator<string, string> {
 }
 
 export class BooleanValidator extends Validator<boolean> {
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<boolean> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<boolean>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure(defaultViolations.notNull(path));
+    } else if (typeof value === 'boolean') {
+      success(value);
+    } else {
+      failure(defaultViolations.boolean(value, path));
     }
-    if (typeof value === 'boolean') {
-      return Promise.resolve(value);
-    }
-    return Promise.reject(defaultViolations.boolean(value, path));
   }
 }
 
@@ -967,15 +1048,16 @@ export abstract class NumberValidatorBase<In> extends Validator<number, In> {
     return new NextNumberValidator<In>(this, new CompositionValidator<number, number>([new MinValidator(min, minInclusive), new MaxValidator(max, maxInclusive)]))
   }
 
-  protected validateNumberFormat(value: number, format: undefined | NumberFormat, path: Path, ctx: ValidationContext) {
+  protected validateNumberFormat(value: number, format: undefined | NumberFormat, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
     switch (format) {
       case NumberFormat.integer:
         if (!Number.isInteger(value)) {
-          return Promise.reject(defaultViolations.number(value, format, path));
+          failure(defaultViolations.number(value, format, path));
+          return;
         }
         break;
     }
-    return Promise.resolve(value);
+    success(value);
   }
 }
 
@@ -1019,9 +1101,10 @@ export class NextNumberValidator<In> extends NumberValidatorBase<In> {
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<number> {
-    return this.firstValidator.validatePath(value, path, ctx).then(
-      firstResult => this.nextValidator.validatePath(firstResult, path, ctx));
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
+    this.firstValidator.validatePathV2(value, path, ctx, 
+      (firstResult) => this.nextValidator.validatePathV2(firstResult, path, ctx, success, failure), 
+      failure);
   }
 }
 
@@ -1031,14 +1114,14 @@ export class NumberValidator extends NumberValidatorBase<number> {
     Object.freeze(this);
   }
 
-  validatePath(value: number, path: Path, ctx: ValidationContext): PromiseLike<number> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      failure(defaultViolations.notNull(path));
+    } else if (!isNumber(value)) {
+      failure(defaultViolations.number(value, this.format, path));
+    } else {
+      super.validateNumberFormat(value, this.format, path, ctx, success, failure);
     }
-    if (!isNumber(value)) {
-      return Promise.reject(defaultViolations.number(value, this.format, path));
-    }
-    return super.validateNumberFormat(value, this.format, path, ctx);
   }
 }
 
@@ -1048,27 +1131,27 @@ export class NumberNormalizer extends NumberValidatorBase<any> {
     Object.freeze(this);
   }
 
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<number> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<number>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
-    }
-    if (isNumber(value)) {
-      return super.validateNumberFormat(value, this.format, path, ctx);
-    }
-    if (value instanceof Number) {
-      return super.validateNumberFormat(value.valueOf(), this.format, path, ctx);
-    }
-    if (isString(value)) {
+      failure(defaultViolations.notNull(path));
+    } else if (isNumber(value)) {
+      super.validateNumberFormat(value, this.format, path, ctx, success, failure);
+    } else if (value instanceof Number) {
+      super.validateNumberFormat(value.valueOf(), this.format, path, ctx, success, failure);
+    } else if (isString(value)) {
       if (value.trim() === '') {
-        return Promise.reject(defaultViolations.number(value, this.format, path));
+        failure(defaultViolations.number(value, this.format, path));
+      } else {
+        const nbr = Number(value);
+        if (isNumber(nbr)) {
+          super.validateNumberFormat(nbr, this.format, path, ctx, success, failure);
+        } else {
+          failure(defaultViolations.number(value, this.format, path));
+        }
       }
-      const nbr = Number(value);
-      if (isNumber(nbr)) {
-        return super.validateNumberFormat(nbr, this.format, path, ctx);
-      }
-      return Promise.reject(defaultViolations.number(value, this.format, path));
+    } else {
+      failure(defaultViolations.number(value, this.format, path));
     }
-    return Promise.reject(defaultViolations.number(value, this.format, path));
   }
 }
 
@@ -1126,17 +1209,19 @@ export class EnumValidator<Out extends Record<string, string | number>> extends 
     Object.freeze(this);
   }
 
-  validatePath(value: unknown, path: Path, ctx: ValidationContext): PromiseLike<Out[keyof Out]> {
+  validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<Out[keyof Out]>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
-    }
+      failure([defaultViolations.notNull(path)]);
+      return;
+    } 
     if (typeof value === 'string' || typeof value === 'number') {
       const isValid = Object.values(this.enumType).includes(value);
       if (isValid) {
-        return Promise.resolve(value as Out[keyof Out]);
+        success(value as Out[keyof Out]);
+        return;
       }
     }
-    return ctx.failure(defaultViolations.enum(this.name, value, path), value);
+    ctx.failureV2(defaultViolations.enum(this.name, value, path), value, success, failure);
   }
 }
 
@@ -1305,11 +1390,12 @@ export class OptionalValidator<Out, In> extends Validator<null | undefined | Out
     Object.freeze(this);
   }
 
-  validatePath(value: null | undefined | In, path: Path, ctx: ValidationContext): PromiseLike<null | undefined | Out> {
+  validatePathV2(value: null | undefined | In, path: Path, ctx: ValidationContext, success: SuccessCallback<null | undefined | Out>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.resolve(value as null | undefined);
+      success(value);
+    } else {
+      this.validator.validatePathV2(value as In, path, ctx, success, failure);
     }
-    return this.validator.validatePath(value as In, path, ctx);
   }
 }
 
@@ -1319,11 +1405,12 @@ export class OptionalUndefinedValidator<Out, In> extends Validator<undefined | O
     Object.freeze(this);
   }
 
-  validatePath(value: undefined | In, path: Path, ctx: ValidationContext): PromiseLike<undefined | Out> {
+  validatePathV2(value: undefined | In, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined | Out>, failure: FailureCallback): void {
     if (value === undefined) {
-      return Promise.resolve(undefined);
+      success(undefined);
+    } else {
+      this.validator.validatePathV2(value, path, ctx, success, failure);
     }
-    return this.validator.validatePath(value, path, ctx);
   }
 }
 
@@ -1333,14 +1420,14 @@ export class NullableValidator<Out, In> extends Validator<null | Out, null | In>
     Object.freeze(this);
   }
 
-  validatePath(value: null | In, path: Path, ctx: ValidationContext): PromiseLike<null | Out> {
+  validatePathV2(value: null | In, path: Path, ctx: ValidationContext, success: SuccessCallback<null | Out>, failure: FailureCallback): void {
     if (value === null) {
-      return Promise.resolve(null);
+      success(null);
+    } else if (value === undefined) {
+      failure([defaultViolations.notUndefined(path)]);
+    } else {
+      this.validator.validatePathV2(value, path, ctx, success, failure);
     }
-    if (value === undefined) {
-      return Promise.reject(defaultViolations.notUndefined(path));
-    }
-    return this.validator.validatePath(value, path, ctx);
   }
 }
 
@@ -1364,27 +1451,28 @@ export class ValueMapper<Out = unknown, In = unknown> extends Validator<Out, In>
     Object.freeze(this);
   }
 
-  validatePath(value: In, path: Path, ctx: ValidationContext): PromiseLike<Out> {
+  validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    const handleResult = (result: any) => {
+      if (result instanceof Violation) {
+        ctx.failureV2(result, value, success, failure);
+      } else {
+        success(result);
+      }
+    };
+
     try {
       const maybePromise = this.fn(value, path, ctx);
       if (isPromise(maybePromise)) {
-        return maybePromise.then(
-          (result: any) => this.handleResult(result, value, ctx),
-          (error: any) => Promise.reject(violationsOf(error, path)),
+        maybePromise.then(
+          handleResult,
+          (error: any) => failure(violationsOf(error, path)),
         );
       } else {
-        return this.handleResult(maybePromise, value, ctx);
+        handleResult(maybePromise);
       }
     } catch (error) {
-      return Promise.reject(violationsOf(error, path));
+      failure(violationsOf(error, path));
     }
-  }
-
-  private handleResult(result: any, value: any, ctx: ValidationContext) {
-    if (result instanceof Violation) {
-      return ctx.failure(result, value);
-    }
-    return Promise.resolve(result);
   }
 }
 

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -5,7 +5,7 @@ import { validate as uuidValidate, version as uuidVersion } from 'uuid';
 const ROOT = Path.ROOT;
 
 export interface ValidatorFn<Out = unknown, In = unknown> {
-  (value: In, path: Path, ctx: ValidationContext): PromiseLike<Out>;
+  (value: In, path: Path, ctx: ValidationContext): Out | PromiseLike<Out>;
 }
 
 export interface ValidatorFnV2<Out = unknown, In = unknown> {
@@ -28,6 +28,7 @@ export class ValidationContext {
 
   /**
   * Optionally ignore an error for backwards compatible changes (enum values, new properties).
+  * @deprecated use failureV2 instead
   */
   failure<Out = unknown, In = unknown>(violation: Violation | Violation[], value: In) {
     return new Promise((resolve, reject) => {
@@ -45,7 +46,7 @@ export class ValidationContext {
       failure(violations);
     }
   }
-  private ignoreViolation(violation: Violation) {
+  protected ignoreViolation(violation: Violation) {
     return (
       (this.options.ignoreUnknownEnumValues && violation.type === ValidatorType.EnumMismatch) ||
       (this.options.ignoreUnknownProperties && violation.type === ValidatorType.UnknownProperty)
@@ -378,7 +379,13 @@ export class ValidatorFnWrapperV2<Out = unknown, In = unknown> extends Validator
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
-    this.fn(value, path, ctx, success, failure);
+    try {
+      this.fn(value, path, ctx, 
+        success, 
+        error => ctx.failureV2(error, value, success, failure));
+    } catch (error) {
+      ctx.failureV2(violationsOf(error, path), value, success, failure);
+    }
   }
 }
 
@@ -390,12 +397,10 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
 
   validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<Out[]>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      failure([defaultViolations.notNull(path)]);
-      return;
+      return failure([defaultViolations.notNull(path)]);
     }
     if (!Array.isArray(value)) {
-      failure([new TypeMismatch(path, 'array', value)]);
-      return;
+      return failure([new TypeMismatch(path, 'array', value)]);
     }
     const convertedArray: Out[] = [];
     if (value.length === 0) {
@@ -566,13 +571,11 @@ export class IfValidator<If = unknown, In = unknown, Else = unknown> extends Val
     for (let i = 0; i < this.conditionals.length; i++) {
       const conditional = this.conditionals[i];
       if (conditional.fn(value, path, ctx)) {
-        conditional.validator.validatePathV2(value, path, ctx, success, failure);
-        return;
+        return conditional.validator.validatePathV2(value, path, ctx, success, failure);
       }
     }
     if (this.elseValidator) {
-      this.elseValidator.validatePathV2(value, path, ctx, success, failure);
-      return;
+      return this.elseValidator.validatePathV2(value, path, ctx, success, failure);
     }
     failure(new Violation(path, 'NoMatchingCondition', value));
   }
@@ -768,13 +771,11 @@ export class MapNormalizer<K = unknown, V = unknown, E extends boolean = true> e
         }
       }
       if (violations.length > 0) {
-        failure(violations);
-        return;
+        return failure(violations);
       }
-      super.validatePathV2(map, path, ctx, success, failure);
-      return; 
+      return super.validatePathV2(map, path, ctx, success, failure);
     }
-    failure(new TypeMismatch(path, 'Map OR array of [key, value] arrays'));
+    return failure(new TypeMismatch(path, 'Map OR array of [key, value] arrays'));
   }
 }
 
@@ -1100,8 +1101,7 @@ export abstract class NumberValidatorBase<In> extends Validator<number, In> {
     switch (format) {
       case NumberFormat.integer:
         if (!Number.isInteger(value)) {
-          failure(defaultViolations.number(value, format, path));
-          return;
+          return failure(defaultViolations.number(value, format, path));
         }
         break;
     }
@@ -1259,14 +1259,12 @@ export class EnumValidator<Out extends Record<string, string | number>> extends 
 
   validatePathV2(value: unknown, path: Path, ctx: ValidationContext, success: SuccessCallback<Out[keyof Out]>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      failure([defaultViolations.notNull(path)]);
-      return;
+      return failure([defaultViolations.notNull(path)]);
     } 
     if (typeof value === 'string' || typeof value === 'number') {
       const isValid = Object.values(this.enumType).includes(value);
       if (isValid) {
-        success(value as Out[keyof Out]);
-        return;
+        return success(value as Out[keyof Out]);
       }
     }
     ctx.failureV2(defaultViolations.enum(this.name, value, path), value, success, failure);
@@ -1324,9 +1322,6 @@ export class HasValueValidator<InOut> extends Validator<InOut> {
 export class AllOfValidator<Out, In> extends Validator<Out, In> {
   constructor(public readonly validators: [Validator<Out, In>, ...Validator<Out, In>[]]) {
     super();
-    if (this.validators.length === 0) {
-      throw new Error('AllOfValidator: At least one validator required');
-    }
     Object.freeze(this.validators);
     Object.freeze(this);
   }

--- a/packages/luxon/src/Vluxon.ts
+++ b/packages/luxon/src/Vluxon.ts
@@ -1,4 +1,4 @@
-import { ValidationContext, isNullOrUndefined, defaultViolations, isString, V, Validator, TypeMismatch } from '@finnair/v-validation';
+import { ValidationContext, isNullOrUndefined, defaultViolations, isString, V, Validator, TypeMismatch, SuccessCallback, FailureCallback } from '@finnair/v-validation';
 import { Path } from '@finnair/path';
 import { DateTime, DateTimeJSOptions, DateTimeOptions, Duration, FixedOffsetZone } from 'luxon';
 import {
@@ -30,25 +30,28 @@ export class DateTimeValidator extends Validator<DateTime> {
     Object.freeze(params);
     Object.freeze(this);
   }
-  validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<DateTime> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<DateTime>, failure: FailureCallback): void {
     const params = this.params;
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
-    }
+      failure(defaultViolations.notNull(path));
+      return;
+    } 
     if (DateTime.isDateTime(value)) {
       if (value.isValid) {
-        return Promise.resolve(value as DateTime);
+        success(value as DateTime);
+        return;
       }
     } else if (isString(value)) {
       const match = params.pattern.exec(value);
       if (match) {
         const dateTime = params.parser(value, match);
         if (dateTime.isValid) {
-          return Promise.resolve(dateTime);
+          success(dateTime);
+          return;
         }
       }
     }
-    return Promise.reject(defaultViolations.date(value, path, params.type));
+    failure(defaultViolations.date(value, path, params.type));
   }
 }
 
@@ -60,18 +63,16 @@ export class LuxonValidator<Out extends LuxonDateTime> extends Validator<Out> {
     Object.freeze(this);
   }
 
-  validatePath(value: any, path: Path, ctx: ValidationContext): PromiseLike<Out> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     if (value instanceof this.params.proto) {
-      return Promise.resolve(value);
+      success(value);
+    } else if (DateTime.isDateTime(value?.dateTime)) {
+      success(new this.params.proto(value.dateTime));
+    } else {
+      this.dateTimeValidator.validatePathV2(value, path, ctx,
+        (result: DateTime) => success(new this.params.proto(result)),
+        failure);
     }
-    if (DateTime.isDateTime(value?.dateTime)) {
-      return Promise.resolve(new this.params.proto(value.dateTime));
-    }
-    return this.dateTimeValidator.validatePath(value, path, ctx).then(
-      (result: DateTime) => {
-        return new this.params.proto(result);
-      }
-    );
   }
 }
 
@@ -232,34 +233,34 @@ const durationPattern =
   /^P(?!$)(\d+(?:\.\d+)?Y)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?W)?(\d+(?:\.\d+)?D)?(T(?=\d)(\d+(?:\.\d+)?H)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?S)?)?$/;
 
 export class DurationValidator extends Validator<Duration> {
-  async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<Duration> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Duration>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     } else if (Duration.isDuration(value)) {
-      return Promise.resolve(value);
+      return success(value);
     } else if (isString(value) && durationPattern.test(value)) {
       const duration = Duration.fromISO(value);
       if (duration.isValid) {
-        return Promise.resolve(duration);
+        return success(duration);
       }
     }
-    return Promise.reject(new TypeMismatch(path, 'Duration', value));
+    return failure(new TypeMismatch(path, 'Duration', value));
   }
 }
 
 export class TimeDurationValidator extends Validator<Duration> {
-  async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<Duration> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Duration>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     } else if (Duration.isDuration(value)) {
-      return Promise.resolve(value);
+      return success(value);
     } else if (isString(value)) {
       const duration = Duration.fromISOTime(value);
       if (duration.isValid) {
-        return Promise.resolve(duration);
+        return success(duration);
       }
     }
-    return Promise.reject(new TypeMismatch(path, 'TimeDuration', value));
+    return failure(new TypeMismatch(path, 'TimeDuration', value));
   }
 }
 

--- a/packages/moment/src/Vmoment.ts
+++ b/packages/moment/src/Vmoment.ts
@@ -1,4 +1,4 @@
-import { Validator, ValidationContext, isNullOrUndefined, defaultViolations, isString, TypeMismatch } from '@finnair/v-validation';
+import { Validator, ValidationContext, isNullOrUndefined, defaultViolations, isString, TypeMismatch, SuccessCallback, FailureCallback } from '@finnair/v-validation';
 import { Path } from '@finnair/path';
 import moment, { Moment, MomentInput } from 'moment';
 
@@ -7,34 +7,34 @@ export class MomentValidator extends Validator<Moment, string | Moment> {
     super();
     Object.freeze(this);
   }
-  async validatePath(value: string | Moment, path: Path, ctx: ValidationContext): Promise<Moment> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<Moment>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if (isString(value) || moment.isMoment(value)) {
       const convertedValue = this.parse(value);
       if (convertedValue.isValid()) {
-        return Promise.resolve(convertedValue);
+        return success(convertedValue);
       }
     }
-    return Promise.reject(defaultViolations.date(value, path, this.type));
+    return failure(defaultViolations.date(value, path, this.type));
   }
 }
 
 const durationPattern =
   /^P(?!$)(\d+(?:\.\d+)?Y)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?W)?(\d+(?:\.\d+)?D)?(T(?=\d)(\d+(?:\.\d+)?H)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?S)?)?$/;
 export class DurationValidator extends Validator<moment.Duration> {
-  async validatePath(value: any, path: Path, ctx: ValidationContext): Promise<moment.Duration> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<moment.Duration>, failure: FailureCallback): void {
     if (isNullOrUndefined(value)) {
-      return Promise.reject(defaultViolations.notNull(path));
+      return failure(defaultViolations.notNull(path));
     }
     if ((isString(value) && durationPattern.test(value)) || moment.isDuration(value)) {
       const convertedValue = moment.duration(value);
       if (convertedValue.isValid()) {
-        return Promise.resolve(convertedValue);
+        return success(convertedValue);
       }
     }
-    return Promise.reject(new TypeMismatch(path, 'Duration', value));
+    return failure(new TypeMismatch(path, 'Duration', value));
   }
 }
 


### PR DESCRIPTION
**Better performing internal validator architecture**
A composite validator using
```
for (const validator of nestedValidators)
promises.push(validator.validate(value));
await Promise.all(promises)
```
turns out to be much slower than
```
for (const validator of nestedValidators) await validator.validate(value)
```
but forcing validators to run synchronously would kill async performance.

This PR refactors the internal architecture to be fully callback based which allows synchronous validators to run without additional Promise-overhead while still allowing async validators to run in parallel. As Promises are also internally implemented through callbacks, this implementation retains high-level compatibility with old Promise-based validator architecture. However, custom validators that extend internal validators (e.g. ObjectValidator) may need to be refactored.

Performance was tested using ~126K MCT rules and resulted in around 3x faster validation (from 3 to 1 sec).

**Drop support for ObjectValidator property filters**
This feature breaks typing and the use case to conditionally validate only selected properties, is nowdays better implemented with `V.if` and `ObjectValidator.pick/omit`.

BREAKING_CHANGE
