### PR TITLE
feat: configurable propertyOrder and optimized optional properties validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# local benchmark datasets - never commit real data. Cases and datasets kept alongside them are
+# covered more thoroughly by benchmark/cases/.gitignore.
+*.jsonl.gz

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,204 @@
+# Benchmark scaffold
+
+Measures validation throughput and memory for validators and data **you** supply. Nothing in here
+carries a dataset: a case file names your model and points at your inputs, and both can be kept out
+of version control.
+
+Build first, since cases import the published entry points rather than `src`:
+
+```bash
+yarn build
+yarn bench example
+```
+
+## Why measure your own data
+
+The gain from v11, and from `propertyOrder` in particular, depends heavily on the shape of your data
+and rules. `propertyOrder` skips validation of optional properties that are *absent*, so the payoff
+is roughly proportional to how many of them actually are. The bundled example makes this visible -
+same validator, same record count, only the share of optional properties present changes:
+
+| optional presence | `propertyOrder([])` vs none |
+| ----------------- | --------------------------- |
+| 0.10              | 3.70x                       |
+| 0.50              | 2.03x                       |
+| 0.95              | 1.07x                       |
+
+```bash
+OPTIONAL_PRESENCE=0.1  yarn bench example
+OPTIONAL_PRESENCE=0.95 yarn bench example
+```
+
+Anything that converts rather than checks - date parsing, custom mappers - is largely unchanged
+between versions, so the more of your time goes there, the smaller the ratio you will see.
+
+## Writing a case
+
+A case default-exports a `data()` function and a map of named validator variants:
+
+```js
+// benchmark/cases/my-rules.local.js
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { V } from '@finnair/v-validation';
+
+const caseDir = dirname(fileURLToPath(import.meta.url));
+const DATA = process.env.MY_DATA ?? resolve(caseDir, 'my-rules.jsonl');
+
+const properties = () => ({ /* ...your model... */ });
+
+export default {
+  name: 'my-rules',
+
+  // Called inside the measured process, before the clock and the memory baseline.
+  // Return (or resolve) an array of inputs.
+  data() {
+    let raw;
+    try {
+      raw = readFileSync(DATA, 'utf8');
+    } catch (error) {
+      throw new Error(`could not read ${DATA} - set MY_DATA to its location (${error.message})`);
+    }
+    return raw.split('\n').filter(line => line.trim()).map(line => JSON.parse(line));
+  },
+
+  // Each variant is a factory, so the validator is built inside the measured process too.
+  variants: {
+    'no propertyOrder': () => V.objectType().properties(properties()).build(),
+    'propertyOrder([])': () => V.objectType().properties(properties()).propertyOrder([]).build(),
+  },
+};
+```
+
+```bash
+yarn bench my-rules.local                          # data beside the case
+MY_DATA=/data/rules.jsonl yarn bench my-rules.local # or anywhere else
+```
+
+`yarn bench <case>` resolves `<case>` as a path first, then as a name under `benchmark/cases/`.
+
+### Where the files go
+
+**The case file has to live under `benchmark/cases/`.** This is a module-resolution constraint, not a
+preference: Node looks for `node_modules` upwards from the case file's own location, so a case parked
+elsewhere on disk cannot `import { V } from '@finnair/v-validation'` and dies with
+`ERR_MODULE_NOT_FOUND`.
+
+**The data can live wherever you like, including right beside the case.** Resolving it relative to
+the case file (as above) makes `yarn bench my-rules.local` work with no environment variable, and an
+env override lets a shared dataset live outside the repo if you prefer.
+
+**Nothing in `benchmark/cases/` is committed unless it is explicitly allowed.** That directory has
+its own `.gitignore` which ignores everything and then re-admits only `example.js`, so a model or a
+dataset dropped there is invisible to git whatever it is called or however it is encoded - no
+reliance on getting a suffix right. To commit a case that is genuinely shareable, add a matching
+`!my-case.js` line to `benchmark/cases/.gitignore`.
+
+The `.local` suffix in `my-rules.local.js` is therefore a readability convention, not the safety
+mechanism: it marks at a glance which cases are private. `git check-ignore -v <file>` confirms any
+individual file if you want to be sure.
+
+Keep `data()` deterministic. Every repetition runs in a fresh process and calls it again, so
+`Math.random()` without a fixed seed makes repetitions incomparable - see the seeded PRNG in
+`cases/example.js`.
+
+## Options
+
+| Flag             | Default  | Meaning                                                              |
+| ---------------- | -------- | -------------------------------------------------------------------- |
+| `--reps N`       | `3`      | Repetitions per variant, each in a fresh process. Tables show medians |
+| `--shape rows`   | `rows`   | One `validate()` call per input                                      |
+| `--shape array`  |          | One `V.array(validator).validate(inputs)` call for the whole dataset  |
+| `--mode retain`  | `retain` | Keep every converted value, so `retained` measures what output costs  |
+| `--mode discard` |          | Drop results - isolates transient allocation from output size         |
+| `--limit N`      | all      | Use only the first N inputs                                          |
+| `--batch N`      | `1000`   | Inputs per event-loop yield (`--shape rows` only)                    |
+| `--json`         | off      | Machine-readable output, including every repetition                   |
+
+### `--shape` matters more than anything else
+
+Pick the shape that matches how you actually call the library, because the two are not small
+variations on each other.
+
+With `--shape rows` every input costs one `validate()` call, so one Promise and one `await` turn per
+input. That overhead is identical in every version, and on a fast validator it is a large share of
+the total - which flattens differences between versions and between variants.
+
+With `--shape array` the whole dataset goes through a single `V.array(...)` call: one Promise for
+the lot. This is what the v11 callback architecture targets, and it is where the difference shows.
+On ~126K MCT rules, v10.2.1 vs v11 measured 1.4x row-by-row but 3.4x as an array; peak heap went
+from 2.3 GB to 157 MB, because the old architecture kept a Promise per property alive for every
+row simultaneously.
+
+Two things not to read across shapes:
+
+- **`peak heap`** in `--shape array` is a lower bound. The single call blocks the event loop, so
+  memory cannot be sampled during it and the figure is taken immediately afterwards.
+- **`gc` counts** are not comparable between shapes at all. A blocked event loop yields roughly the
+  same small number of collections whatever the version, so `gc` only tells you something within a
+  shape - it is a useful churn signal in `--shape rows` and near-meaningless in `--shape array`.
+
+`retained` is unaffected: the same validated values are produced either way.
+
+## Reading the output
+
+```
+variant                       ms       ops/s      rel   peak heap   peak rss   retained     gc   gc ms
+------------------------------------------------------------------------------------------------------
+no propertyOrder             212      94,272    1.00x     42.5 MB   135.3 MB       7 MB     29      30
+propertyOrder([])             92     216,399    2.30x     17.1 MB   105.3 MB     6.4 MB     22      27
+```
+
+- **rel** - relative to the first variant, which is the intended baseline. Order your variants
+  accordingly. It compares variants within one run, so unless a case deliberately imports two
+  releases (see below) this is not a version comparison.
+- **retained** - heap still held after a forced GC with the converted values referenced. In
+  `--mode retain` this is what your validated output costs to keep; in `--mode discard` nothing is
+  kept, so it reads `n/a`.
+- **peak heap** - highest `heapUsed` above the post-baseline reading. In `--shape rows` it is
+  sampled at batch boundaries; in `--shape array` see the note above. Read it together with **gc**:
+  fewer collections let the young generation fill further, so a slightly higher peak alongside far
+  fewer GCs means less pressure, not more demand.
+- **gc / gc ms** - collections and total pause time during the run, mostly scavenges.
+
+Validation failures are reported as a warning and make the numbers incomparable - failing inputs
+take a different path, constructing violations - so fix the case or the data before reading them.
+
+## What is and is not measured
+
+Loading and parsing input, and building the validator, both happen before the clock starts and
+before the memory baseline is taken. Only `validate()` calls are timed - one per input in
+`--shape rows`, exactly one in `--shape array`. Everything goes through the public API, and the
+calling pattern is identical for every variant in a run.
+
+Each repetition is a fresh process, so JIT state and heap growth do not leak between variants.
+Medians are reported; the raw per-repetition timings are printed underneath, and a wide spread there
+is your signal that the machine was too noisy to trust the run.
+
+## Comparing against a different release
+
+The scaffold compares variants inside one process, so a cross-version comparison needs both releases
+importable at once. Install the old one under an alias:
+
+```bash
+npm install --no-save "v10@npm:@finnair/v-validation@10.2.1"
+```
+
+```js
+import { V as V11 } from '@finnair/v-validation';
+import { V as V10 } from 'v10';
+```
+
+Note the `<alias>@npm:<package>@<version>` form - `v10:@finnair/...` is rejected as an invalid
+package name. Be aware this adds a dependency to the workspace root, which is why the measurements
+quoted above were taken differently: two throwaway directories outside the repo, one with
+`@finnair/v-validation@10.2.1` from npm and one with `yarn pack` tarballs of the local packages, each
+running the same script. That keeps the workspace untouched and guarantees the two builds cannot
+share hoisted dependencies.
+
+Whichever way you do it, a validator built with a different release of a companion package (for
+example `@finnair/v-validation-luxon`) brings that package's changes into the comparison too. To
+attribute a difference to core alone, substitute a plain `V.string()` for such converting validators
+in both variants - `cases/example.js` has no such dependency, and the MCT case does this behind
+`DATES=string`.

--- a/benchmark/cases/.gitignore
+++ b/benchmark/cases/.gitignore
@@ -1,0 +1,6 @@
+# Cases and their datasets are private by default: this directory holds real models and real data.
+# Nothing here is committed unless it is explicitly allowed below, so dropping a dataset next to its
+# case can never leak it, whatever the file extension.
+*
+!.gitignore
+!example.js

--- a/benchmark/cases/example.js
+++ b/benchmark/cases/example.js
@@ -1,0 +1,86 @@
+/*
+ * Worked example. Generates its own synthetic data, so it runs with no setup:
+ *
+ *   yarn bench example
+ *
+ * The point of this case is to show how much the gain depends on the data. Most of the
+ * `propertyOrder` win comes from optional properties being *absent*, so vary the presence rate
+ * and watch `rel` move:
+ *
+ *   OPTIONAL_PRESENCE=0.1 yarn bench example    # sparse  - propertyOrder pays off most
+ *   OPTIONAL_PRESENCE=0.9 yarn bench example    # dense   - little left to skip
+ *
+ * Copy this file to make your own case: point `data()` at your real inputs and `variants` at the
+ * validators you want to compare.
+ */
+import { V } from '@finnair/v-validation';
+
+const COUNT = Number(process.env.COUNT ?? 100_000);
+const OPTIONAL_PRESENCE = Number(process.env.OPTIONAL_PRESENCE ?? 0.35);
+
+const Status = { ACTIVE: 'ACTIVE', PENDING: 'PENDING', CLOSED: 'CLOSED' };
+const Category = { A: 'A', B: 'B', C: 'C', D: 'D' };
+
+const REQUIRED = ['id', 'name', 'status', 'category'];
+const OPTIONAL_STRINGS = ['ref1', 'ref2', 'ref3', 'ref4', 'ref5', 'ref6', 'ref7', 'ref8'];
+const OPTIONAL_NUMBERS = ['n1', 'n2', 'n3', 'n4', 'n5', 'n6'];
+const OPTIONAL_ENUMS = ['e1', 'e2', 'e3'];
+const OPTIONAL_PATTERNS = ['p1', 'p2', 'p3'];
+
+const properties = () => {
+  const model = {
+    id: V.string(),
+    name: V.string(),
+    status: V.enum(Status, 'Status'),
+    category: V.enum(Category, 'Category'),
+  };
+  for (const key of OPTIONAL_STRINGS) model[key] = V.optionalStrict(V.string());
+  for (const key of OPTIONAL_NUMBERS) model[key] = V.optionalStrict(V.number());
+  for (const key of OPTIONAL_ENUMS) model[key] = V.optionalStrict(V.enum(Category, 'Category'));
+  for (const key of OPTIONAL_PATTERNS) model[key] = V.optionalStrict(V.pattern(/^\d{4}-\d{2}$/));
+  return model;
+};
+
+/** Deterministic PRNG - every repetition must see byte-identical input. */
+const prng = seed => () => {
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = seed;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+export default {
+  name: `example (${COUNT.toLocaleString('en-US')} records, optional presence ${OPTIONAL_PRESENCE})`,
+
+  data() {
+    const statuses = Object.keys(Status);
+    const categories = Object.keys(Category);
+    const records = [];
+    for (let i = 0; i < COUNT; i++) {
+      const random = prng(i * 2654435761);
+      const record = {
+        id: `id-${i}`,
+        name: `name-${i}`,
+        status: statuses[i % statuses.length],
+        category: categories[i % categories.length],
+      };
+      for (const key of OPTIONAL_STRINGS) if (random() < OPTIONAL_PRESENCE) record[key] = `${key}-${i}`;
+      for (const key of OPTIONAL_NUMBERS) if (random() < OPTIONAL_PRESENCE) record[key] = i % 1000;
+      for (const key of OPTIONAL_ENUMS) if (random() < OPTIONAL_PRESENCE) record[key] = categories[i % categories.length];
+      for (const key of OPTIONAL_PATTERNS) if (random() < OPTIONAL_PRESENCE) record[key] = '2026-05';
+      records.push(record);
+    }
+    return records;
+  },
+
+  variants: {
+    'no propertyOrder': () => V.objectType().properties(properties()).build(),
+
+    'propertyOrder([])': () => V.objectType().properties(properties()).propertyOrder([]).build(),
+
+    // Required properties first, optional ones left out, so missing optionals are skipped
+    // while the output keeps a stable, declared order.
+    'propertyOrder(required)': () => V.objectType().properties(properties()).propertyOrder(REQUIRED).build(),
+  },
+};

--- a/benchmark/measure.js
+++ b/benchmark/measure.js
@@ -1,0 +1,140 @@
+/*
+ * Measures one variant of one benchmark case, in its own process, and prints a single JSON line.
+ * Driven by run.js - see benchmark/README.md. Requires --expose-gc.
+ */
+import { pathToFileURL } from 'node:url';
+import { PerformanceObserver, constants } from 'node:perf_hooks';
+import { V } from '@finnair/v-validation';
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i].replace(/^--/, ''), process.argv[i + 1]);
+}
+
+const casePath = args.get('case');
+const variantName = args.get('variant');
+const mode = args.get('mode') ?? 'retain';
+const shape = args.get('shape') ?? 'rows';
+const limit = args.get('limit') ? Number(args.get('limit')) : Infinity;
+const batch = Number(args.get('batch') ?? 1000);
+
+if (typeof global.gc !== 'function') {
+  console.error('measure.js requires --expose-gc');
+  process.exit(1);
+}
+
+const GC_NAMES = {
+  [constants.NODE_PERFORMANCE_GC_MINOR]: 'scavenge',
+  [constants.NODE_PERFORMANCE_GC_MAJOR]: 'major',
+  [constants.NODE_PERFORMANCE_GC_INCREMENTAL]: 'incremental',
+  [constants.NODE_PERFORMANCE_GC_WEAKCB]: 'weakcb',
+};
+let gcRuns = 0;
+let gcMs = 0;
+const gcKinds = {};
+new PerformanceObserver(list => {
+  for (const entry of list.getEntries()) {
+    gcRuns++;
+    gcMs += entry.duration;
+    const kind = GC_NAMES[entry.detail?.kind] ?? String(entry.detail?.kind);
+    gcKinds[kind] = (gcKinds[kind] ?? 0) + 1;
+  }
+}).observe({ entryTypes: ['gc'] });
+
+const mb = bytes => Math.round((bytes / 1048576) * 10) / 10;
+const settle = () => new Promise(resolve => setImmediate(resolve));
+
+const benchmarkCase = (await import(pathToFileURL(casePath).href)).default;
+const variant = benchmarkCase.variants[variantName];
+if (!variant) {
+  console.error(`unknown variant "${variantName}" in ${casePath}`);
+  process.exit(1);
+}
+
+// Input is prepared and the validator built *before* the baseline, so neither is measured.
+const all = await benchmarkCase.data();
+const input = Number.isFinite(limit) ? all.slice(0, limit) : all;
+const validator = await variant();
+
+global.gc();
+global.gc();
+await settle();
+global.gc();
+const baseline = process.memoryUsage();
+gcRuns = 0;
+gcMs = 0;
+for (const key of Object.keys(gcKinds)) delete gcKinds[key];
+
+let peakHeap = baseline.heapUsed;
+let peakRss = baseline.rss;
+let retainedValues = [];
+let failures = 0;
+let firstViolation;
+
+const sample = () => {
+  const usage = process.memoryUsage();
+  if (usage.heapUsed > peakHeap) peakHeap = usage.heapUsed;
+  if (usage.rss > peakRss) peakRss = usage.rss;
+};
+
+const start = process.hrtime.bigint();
+if (shape === 'array') {
+  // One validate() call for the whole dataset: a single awaited Promise rather than one per row,
+  // which is what the internal architecture refactoring actually targets.
+  const result = await V.array(validator).validate(input);
+  if (result.isSuccess()) {
+    if (mode === 'retain') retainedValues = result.getValue();
+  } else {
+    const violations = result.getViolations();
+    failures = violations.length;
+    firstViolation = JSON.stringify(violations[0]);
+  }
+} else {
+  for (let i = 0; i < input.length; i += batch) {
+    const end = Math.min(i + batch, input.length);
+    for (let j = i; j < end; j++) {
+      const result = await validator.validate(input[j]);
+      if (!result.isSuccess()) {
+        failures++;
+        firstViolation ??= JSON.stringify(result.getViolations()[0]);
+        continue;
+      }
+      if (mode === 'retain') retainedValues.push(result.getValue());
+    }
+    // Yield so timers and GC can run, and sample memory at a safe point.
+    await settle();
+    sample();
+  }
+}
+const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+
+sample();
+
+// Retained: force GC while the converted values are still referenced.
+global.gc();
+global.gc();
+await settle();
+global.gc();
+const retainedMb = mb(process.memoryUsage().heapUsed - baseline.heapUsed);
+const retainedCount = retainedValues.length;
+
+console.log(
+  JSON.stringify({
+    variant: variantName,
+    mode,
+    shape,
+    inputs: input.length,
+    failures,
+    firstViolation,
+    retainedCount,
+    ms: Math.round(elapsedMs),
+    opsPerSec: Math.round(input.length / (elapsedMs / 1000)),
+    peakHeapDeltaMb: mb(peakHeap - baseline.heapUsed),
+    peakRssMb: mb(peakRss),
+    retainedMb,
+    gcRuns,
+    gcMs: Math.round(gcMs),
+    gcKinds,
+  }),
+);
+process.exit(0);

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -1,0 +1,148 @@
+/*
+ * Benchmark driver. Runs every variant of a case in a fresh process, repeatedly, and reports
+ * medians. See benchmark/README.md.
+ *
+ *   node benchmark/run.js <case> [--reps 3] [--shape rows|array] [--mode retain|discard] [--limit N] [--batch 1000] [--json]
+ */
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { resolve, dirname } from 'node:path';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const positional = [];
+const flags = new Map();
+for (let i = 2; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (arg === '--json') flags.set('json', 'true');
+  else if (arg.startsWith('--')) flags.set(arg.slice(2), process.argv[++i]);
+  else positional.push(arg);
+}
+
+if (positional.length !== 1) {
+  console.error('usage: node benchmark/run.js <case> [--reps 3] [--shape rows|array] [--mode retain|discard] [--limit N] [--batch 1000] [--json]');
+  console.error('  <case> is a path to a case module, or a name under benchmark/cases/');
+  process.exit(1);
+}
+
+const casePath = (() => {
+  const direct = resolve(process.cwd(), positional[0]);
+  if (existsSync(direct)) return direct;
+  for (const candidate of [`${positional[0]}.js`, `${positional[0]}.mjs`, positional[0]]) {
+    const inCases = resolve(here, 'cases', candidate);
+    if (existsSync(inCases)) return inCases;
+  }
+  console.error(`case not found: ${positional[0]}`);
+  process.exit(1);
+})();
+
+const reps = Number(flags.get('reps') ?? 3);
+const mode = flags.get('mode') ?? 'retain';
+const shape = flags.get('shape') ?? 'rows';
+const asJson = flags.has('json');
+
+if (!['rows', 'array'].includes(shape)) {
+  console.error(`--shape must be "rows" or "array", got "${shape}"`);
+  process.exit(1);
+}
+
+// Importing the case must be cheap - data() is only called inside the measured process.
+const benchmarkCase = (await import(pathToFileURL(casePath).href)).default;
+if (!benchmarkCase?.variants || typeof benchmarkCase.data !== 'function') {
+  console.error(`${casePath} must default-export { name?, data(), variants: { [name]: () => validator } }`);
+  process.exit(1);
+}
+const variantNames = Object.keys(benchmarkCase.variants);
+if (variantNames.length === 0) {
+  console.error(`${casePath} defines no variants`);
+  process.exit(1);
+}
+
+const median = values => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+};
+
+const results = [];
+for (const variant of variantNames) {
+  const runs = [];
+  for (let rep = 0; rep < reps; rep++) {
+    const argv = ['--expose-gc', resolve(here, 'measure.js'), '--case', casePath, '--variant', variant, '--mode', mode, '--shape', shape];
+    if (flags.get('limit')) argv.push('--limit', flags.get('limit'));
+    if (flags.get('batch')) argv.push('--batch', flags.get('batch'));
+    let stdout;
+    try {
+      stdout = execFileSync(process.execPath, argv, { encoding: 'utf8', maxBuffer: 1 << 24, stdio: ['ignore', 'pipe', 'inherit'] });
+    } catch {
+      console.error(`\nvariant "${variant}" failed - see the error above`);
+      process.exit(1);
+    }
+    runs.push(JSON.parse(stdout.trim().split('\n').pop()));
+    if (!asJson) process.stderr.write('.');
+  }
+  results.push({
+    variant,
+    inputs: runs[0].inputs,
+    failures: runs[0].failures,
+    firstViolation: runs[0].firstViolation,
+    ms: median(runs.map(r => r.ms)),
+    opsPerSec: median(runs.map(r => r.opsPerSec)),
+    peakHeapDeltaMb: median(runs.map(r => r.peakHeapDeltaMb)),
+    peakRssMb: median(runs.map(r => r.peakRssMb)),
+    retainedMb: median(runs.map(r => r.retainedMb)),
+    gcRuns: median(runs.map(r => r.gcRuns)),
+    gcMs: median(runs.map(r => r.gcMs)),
+    msRuns: runs.map(r => r.ms),
+  });
+  if (!asJson) process.stderr.write(` ${variant}\n`);
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ case: benchmarkCase.name ?? casePath, mode, shape, reps, node: process.version, results }, null, 2));
+  process.exit(0);
+}
+
+const first = results[0];
+const columns = [
+  { head: 'variant', width: Math.max(7, ...results.map(r => r.variant.length)), align: 'left', value: r => r.variant },
+  { head: 'ms', width: 7, value: r => String(r.ms) },
+  { head: 'ops/s', width: 10, value: r => r.opsPerSec.toLocaleString('en-US') },
+  // Guard against a run too short to register a whole millisecond, which would divide by zero.
+  { head: 'rel', width: 7, value: r => (first.ms > 0 && r.ms > 0 ? (first.ms / r.ms).toFixed(2) + 'x' : '-') },
+  { head: 'peak heap', width: 10, value: r => r.peakHeapDeltaMb + ' MB' },
+  { head: 'peak rss', width: 9, value: r => r.peakRssMb + ' MB' },
+  // Only meaningful when results are kept; in discard mode it is noise around zero.
+  { head: 'retained', width: 9, value: r => (mode === 'retain' ? r.retainedMb + ' MB' : 'n/a') },
+  { head: 'gc', width: 5, value: r => String(r.gcRuns) },
+  { head: 'gc ms', width: 6, value: r => String(r.gcMs) },
+];
+const cell = (text, col) => (col.align === 'left' ? String(text).padEnd(col.width) : String(text).padStart(col.width));
+
+const shapeNote = shape === 'array' ? 'one V.array() call' : 'one validate() call per row';
+console.log(`\n${benchmarkCase.name ?? casePath}  -  ${first.inputs.toLocaleString('en-US')} inputs, shape=${shape} (${shapeNote}), mode=${mode}, median of ${reps}, ${process.version}\n`);
+console.log(columns.map(c => cell(c.head, c)).join('  '));
+console.log('-'.repeat(columns.reduce((sum, c) => sum + c.width + 2, -2)));
+for (const result of results) {
+  console.log(columns.map(c => cell(c.value(result), c)).join('  '));
+}
+console.log(`\nraw ms: ${results.map(r => `${r.variant}=[${r.msRuns.join(', ')}]`).join('  ')}`);
+
+const TOO_SHORT_MS = 20;
+if (results.some(r => r.ms < TOO_SHORT_MS)) {
+  console.log(
+    `\nWARNING  a run finished in under ${TOO_SHORT_MS} ms, which is dominated by measurement noise - ` +
+      'memory figures may even come out slightly negative. Use more inputs or raise --reps.',
+  );
+}
+
+const failing = results.filter(r => r.failures > 0);
+if (failing.length > 0) {
+  console.log('');
+  for (const result of failing) {
+    console.log(`WARNING  ${result.variant}: ${result.failures} of ${result.inputs} inputs failed validation - first violation ${result.firstViolation}`);
+  }
+  console.log('Failing inputs take a different code path (violations are constructed), so the numbers above are not comparable to a clean run.');
+}
+console.log('');

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "lerna run build",
     "test": "vitest --run",
+    "bench": "node benchmark/run.js",
     "clean": "yarn clean:dist && yarn clean:modules && yarn clean:tscache",
     "clean:dist": "find . -type f -path '*/dist/*' -delete && find . -type d -name dist -empty -delete",
     "clean:modules": "find . -type f -path '*/node_modules/*' -delete && find . -type d -name node_modules -empty -delete",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "arrowParens": "avoid"
   },
   "engines": {
-    "node": ">= 20"
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,16 +23,21 @@ Or [`npm`](https://www.npmjs.com/):
 npm install @finnair/v-validation
 ```
 
-## Major Changes Coming in Version 11
+## Major Changes (Coming) in Version 11
 
+### Breaking Changes
 Version 11 introduces better performing internal validator architecture. 
 
 This version refactors the internal architecture to be fully callback based which allows both synchronous and asynchronous validators to run without additional Promise/async-await overhead. From public API perspective (`Validator.validate/getValid`) nothing changes. Old and new validators can also be combined. However, **custom validators that extend internal validators (e.g. `ObjectValidator`) may need to be refactored**. 
 
 Performance was tested using ~126K MCT rules and resulted in around 3x faster validation (from 3 to 1 sec).
 
-**Drop support for ObjectValidator property filters**
+### Drop support for ObjectValidator Property Filters
 ObjectValidator's property filter (which was available for subclasses to utilize) has been dropped. That feature broke typing, and the use case to conditionally validate only selected properties, is nowdays better implemented with `V.if` and `ObjectValidator.pick/omit`.
+
+### New feature: Configurable `propertyOrder` and Optimized Optional Properties Validation
+
+ObjectValidator allows defining custom `propertyOrder`, and when it's is defined, validation of missing optional properties is fully skipped. Using `propertyOrder` results in significantly better performance for object types with many optional properties.
 
 ## Major Changes in Version 8
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,13 +34,14 @@ This version refactors the internal architecture to be fully callback based whic
 
 Performance was tested using ~126K MCT rules and resulted in around 3x faster validation (from 3 to 1 sec).
 
-#### AnyOf Semantics Clarified
+#### AnyOf Semantics Clarified and Fixed
 `V.anyOf` validator no longer short-circuits on first success. Also just like `V.allOf` it now expects all succeeding 
 child validators to return `deepEquals` result. This is to make the result of this validator predicatable regardless 
-of whether underlying validators are sync or async.
+of whether underlying validators are sync or async. Unfortunate side-effect is worse performance than before. Please
+consider using other constructs instead, e.g. `V.if(condition1, validator1).elseIf(condition2, validator2).else(elseValidator)`.
 
-### Drop support for ObjectValidator Property Filters
-ObjectValidator's property filter (which was available for subclasses to utilize) has been dropped. That feature broke typing, and the use case to conditionally validate only selected properties, is nowdays better implemented with `V.if` and `ObjectValidator.pick/omit`.
+#### Drop support for ObjectValidator Property Filters
+ObjectValidator's property filter (which was available for subclasses to utilize) has been dropped. That feature broke typing, and the use case to conditionally validate only selected properties, is better implemented with `V.if` and `ObjectValidator.pick/omit`.
 
 ### New feature: Configurable `propertyOrder` and Optimized Optional Properties Validation
 
@@ -730,7 +731,7 @@ Unless otherwise stated, all validators require non-null and non-undefined value
 | array                   | ...items: Validator[]                                            | [Array validator](#array)                                                                                                                 |
 | toArray                 | items: Validator                                                 | Converts undefined to an empty array and non-arrays to single-valued arrays.                                                              |
 | size                    | min: number, max: number                                         | Asserts that input's numeric `length` property is between min and max (both inclusive).                                                   |
-| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. All chidl validators must result in the same output.                                |
+| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. All child validators must result in the same output.                                |
 | anyOf                   | ...validators: Validator[]                                       | Requires minimum one of given validators matches. All matching validators must result in the same output.  |
 | oneOf                   | ...validators: Validator[]                                       | Requires that exactly one of the given validators match.                                                                                  |
 | emptyToUndefined        |                                                                  | Converts null or empty string to undefined. Does not touch any other values.                                                              |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,7 +37,7 @@ ObjectValidator's property filter (which was available for subclasses to utilize
 
 ### New feature: Configurable `propertyOrder` and Optimized Optional Properties Validation
 
-ObjectValidator allows defining custom `propertyOrder`, and when it's is defined, validation of missing optional properties is fully skipped. Using `propertyOrder` results in significantly better performance for object types with many optional properties.
+ObjectValidator allows defining custom `propertyOrder`, and when it's defined, validation of missing optional properties is fully skipped. Using `propertyOrder` results in significantly better performance for object types with many optional properties.
 
 ## Major Changes in Version 8
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,18 +26,25 @@ npm install @finnair/v-validation
 ## Major Changes (Coming) in Version 11
 
 ### Breaking Changes
+
+#### Internal Architecture
 Version 11 introduces better performing internal validator architecture. 
 
 This version refactors the internal architecture to be fully callback based which allows both synchronous and asynchronous validators to run without additional Promise/async-await overhead. From public API perspective (`Validator.validate/getValid`) nothing changes. Old and new validators can also be combined. However, **custom validators that extend internal validators (e.g. `ObjectValidator`) may need to be refactored**. 
 
 Performance was tested using ~126K MCT rules and resulted in around 3x faster validation (from 3 to 1 sec).
 
+#### AnyOf Semantics Clarified
+`V.anyOf` validator no longer short-circuits on first success. Also just like `V.allOf` it now expects all succeeding 
+child validators to return `deepEquals` result. This is to make the result of this validator predicatable regardless 
+of whether underlying validators are sync or async.
+
 ### Drop support for ObjectValidator Property Filters
 ObjectValidator's property filter (which was available for subclasses to utilize) has been dropped. That feature broke typing, and the use case to conditionally validate only selected properties, is nowdays better implemented with `V.if` and `ObjectValidator.pick/omit`.
 
 ### New feature: Configurable `propertyOrder` and Optimized Optional Properties Validation
 
-ObjectValidator allows defining custom `propertyOrder`, and when it's defined, validation of missing optional properties is fully skipped. Using `propertyOrder` results in significantly better performance for object types with many optional properties.
+ObjectValidator allows defining custom `propertyOrder`, and when it's defined, validation of missing optional properties that are not included in `propertyOrder` are fully skipped. Using `propertyOrder` results in significantly better performance for object types with many optional properties.
 
 ## Major Changes in Version 8
 
@@ -329,8 +336,8 @@ but that something may then cause "is declared but never used" -error.
 
 - All validators have [`Validator.next`](#next) function to chain validator rules. 
 - `compositionOf` - validators are run one after another against the (current) converted value (a shortcut for [`Validator.next`](#next)).
-- `allOf` - the input value must satisfy all the validators. Validators are run in parallel and must return the same value (deepEquals).
-- `anyOf` - at least one of the validators must match.
+- `allOf` - the input value must satisfy all the validators. All validators must return the same value (deepEquals).
+- `anyOf` - at least one of the validators must match. All matching validators must return the same value (deepEquals).
 - `oneOf` - exactly one validator must match while others should return false.
 
 ## <a name="object">V.object</a>
@@ -723,8 +730,8 @@ Unless otherwise stated, all validators require non-null and non-undefined value
 | array                   | ...items: Validator[]                                            | [Array validator](#array)                                                                                                                 |
 | toArray                 | items: Validator                                                 | Converts undefined to an empty array and non-arrays to single-valued arrays.                                                              |
 | size                    | min: number, max: number                                         | Asserts that input's numeric `length` property is between min and max (both inclusive).                                                   |
-| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. Validators are run in parallel and must provide the same output.                                |
-| anyOf                   | ...validators: Validator[]                                       | Requires minimum one of given validators matches. Validators are run in parallel and in case of failure, all violations will be returned. |
+| allOf                   | ...validators: Validator[]                                       | Requires that all given validators match. All chidl validators must result in the same output.                                |
+| anyOf                   | ...validators: Validator[]                                       | Requires minimum one of given validators matches. All matching validators must result in the same output.  |
 | oneOf                   | ...validators: Validator[]                                       | Requires that exactly one of the given validators match.                                                                                  |
 | emptyToUndefined        |                                                                  | Converts null or empty string to undefined. Does not touch any other values.                                                              |
 | emptyToNull             |                                                                  | Converts undefined or empty string to null. Does not touch any other values.                                                              |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,7 +32,7 @@ Version 11 introduces better performing internal validator architecture.
 
 This version refactors the internal architecture to be fully callback based which allows both synchronous and asynchronous validators to run without additional Promise/async-await overhead. From public API perspective (`Validator.validate/getValid`) nothing changes. Old and new validators can also be combined. However, **custom validators that extend internal validators (e.g. `ObjectValidator`) may need to be refactored**. 
 
-Performance was tested using ~126K MCT rules and resulted in around 3x faster validation (from 3 to 1 sec).
+See [Performance](#performance) for measurements.
 
 #### AnyOf Semantics Clarified and Fixed
 `V.anyOf` validator no longer short-circuits on first success. Also just like `V.allOf` it now expects all succeeding 
@@ -49,6 +49,43 @@ ObjectValidator's property filter (which was available for subclasses to utilize
 ### New feature: Configurable `propertyOrder` and Optimized Optional Properties Validation
 
 ObjectValidator allows defining custom `propertyOrder`, and when it's defined, validation of missing optional properties that are not included in `propertyOrder` are fully skipped. Using `propertyOrder` results in significantly better performance for object types with many optional properties.
+
+### Performance
+
+Measured on ~126K real MCT rules - 26 properties, most of them optional and absent on any given
+record - validated as one array (`V.array(ruleValidator)`) against the previous release 10.2.1, on
+Node 20:
+
+|                      | time    | throughput   | peak heap | retained heap |
+| -------------------- | ------- | ------------ | --------- | ------------- |
+| 10.2.1               | 2925 ms | 43K rules/s  | 537 MB    | 108 MB        |
+| 11                   | 744 ms  | 170K rules/s | 32 MB     | 18 MB         |
+| 11 + `propertyOrder` | 288 ms  | 439K rules/s | 29 MB     | 17 MB         |
+
+Two separate wins: the callback architecture accounts for 3.9x, and opting in to `propertyOrder`
+multiplies that by a further 2.6x.
+
+**How you call the library matters as much as the version.** Validating a collection as one
+`V.array(...)` call is a single Promise for the whole dataset; validating row by row costs a
+`validate()` Promise and an `await` turn per row, and that overhead is the same in every version. On
+the same data and validator, row-by-row measures 1.6x / 4.0x where the array measures 3.9x / 10.2x.
+
+**The peak memory difference is the bigger operational change.** Validating that array on 10.2.1
+peaked at 2.3 GB of heap with `Vluxon.localDate()` in the model, because a Promise per property was
+held alive for every row at once; the same work on v11 peaks at 157 MB. Under
+`--max-old-space-size=1024` the 10.2.1 run dies with *"Ineffective mark-compacts near heap limit"*
+while v11 completes, so collections that previously needed chunking to fit in a container may no
+longer need it.
+
+**Expect different numbers.** The gain depends heavily on the shape of your data and rules, and
+`propertyOrder` pays off in proportion to how many optional properties are actually absent. Adding
+three `Vluxon.localDate()` conversions - a cost unchanged between versions - moves the array
+measurement from 3.9x / 10.2x to 3.4x / 5.7x, because less of the total time is core validation.
+Measure your own schema against your own data with the [benchmark scaffold](../../benchmark).
+
+Converted output is unchanged, but v11 returns objects with V8 *fast properties* where 10.2.1
+returned dictionary-mode objects. That accounts for most of the retained-heap difference, even
+though the validated values are identical.
 
 ## Major Changes in Version 8
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,9 +36,12 @@ Performance was tested using ~126K MCT rules and resulted in around 3x faster va
 
 #### AnyOf Semantics Clarified and Fixed
 `V.anyOf` validator no longer short-circuits on first success. Also just like `V.allOf` it now expects all succeeding 
-child validators to return `deepEquals` result. This is to make the result of this validator predicatable regardless 
+child validators to return `deepEquals` result. This is to make the result of this validator predictable regardless 
 of whether underlying validators are sync or async. Unfortunate side-effect is worse performance than before. Please
 consider using other constructs instead, e.g. `V.if(condition1, validator1).elseIf(condition2, validator2).else(elseValidator)`.
+
+Since every branch now runs, `V.anyOf` also reports ignored violations to `warnLogger` once per branch instead of once
+in total. See [Deduplicating `warnLogger` with `dedupWarnLogger`](#deduplicating-warnlogger-with-dedupwarnlogger).
 
 #### Drop support for ObjectValidator Property Filters
 ObjectValidator's property filter (which was available for subclasses to utilize) has been dropped. That feature broke typing, and the use case to conditionally validate only selected properties, is better implemented with `V.if` and `ObjectValidator.pick/omit`.
@@ -632,6 +635,41 @@ Options are passed to to `validate` function as optional second argument.
 (await V.object({ additionalProperties: false }).validate({ additionalProperty: 'Not OK' }, { ignoreUnknownProperties: true })).isSuccess();
 // false
 ```
+
+### Deduplicating `warnLogger` with `dedupWarnLogger`
+
+`warnLogger` reports ignored `Violation`s, i.e. backwards compatible changes in source data: a
+source system started sending a new property, or a new enum value. That is a small and fixed set of
+findings, but `warnLogger` is called for every *occurrence* of one, so an undeduplicated logger
+reports the same finding over and over:
+
+- once per array element - and elements of an array share the same schema, so a new property in a
+  1000 element array is one finding reported 1000 times,
+- once per child validator of `V.anyOf`, `V.oneOf`, `V.allOf` and validator chains
+  (`Validator.next`/`V.compositionOf`), since each of them validates the same value,
+- and, most importantly, again on every single request until the validator is updated.
+
+Wrap your logger in `dedupWarnLogger` to report each distinct finding only once. Create it **once**
+and reuse it, so that deduplication spans validations - that is where the volume comes from:
+
+```typescript
+import { dedupWarnLogger } from '@finnair/v-validation';
+
+const warnLogger = dedupWarnLogger(violation => console.warn('Source data changed:', violation));
+
+// per request
+await validator.validate(input, { ignoreUnknownProperties: true, warnLogger });
+```
+
+Findings are identified by `warnLoggerKey`: violation type, path and `invalidValue`, with array
+indices replaced by `*` (`$.items[3].added` becomes `$.items[*].added` - see `anyIndexPath`). So a
+new property is reported once no matter which element or which request it arrives in, while genuinely
+different findings are all still reported: a different property, a different location in the schema,
+or a different unknown enum value. Pass a second argument to use a different identity.
+
+The set of reported findings is retained for the lifetime of the returned logger. It is bounded by
+the schema - violation type times normalized path times enum value - not by the amount of data
+validated.
 
 ## Custom Validators
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,9 +40,8 @@
     "build:esm": "tsc -b . && cp ../../package.esm.json dist/esm/package.json"
   },
   "dependencies": {
-    "@types/uuid": "10.0.0",
     "fast-deep-equal": "3.1.3",
-    "uuid": "10.0.0"
+    "uuid": "14.0.2"
   },
   "peerDependencies": {
     "@finnair/path": ">=7"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,5 +48,8 @@
   },
   "devDependencies": {
     "@finnair/path": "^10.2.1"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -976,18 +976,74 @@ describe('inheritance', () => {
     await expectViolations({}, type, defaultViolations.notNull(property('required')));
   });
 
-  test('property order', async () => {
-    const value = (
-      await multiParentChild.validate({
-        firstAdditional: 'firstAdditional',
-        name: 'multi-parent',
-        additionalProperty: 2,
-        thirdAdditional: 'thirdAdditional',
-        anything: true,
-        id: '123',
-      })
-    ).getValue();
-    expect(Object.keys(value)).toEqual(['id', 'name', 'anything', 'firstAdditional', 'additionalProperty', 'thirdAdditional']);
+  describe('property order', () => {
+    test('default property order', async () => {
+      const value = (
+        await multiParentChild.validate({
+          firstAdditional: 'firstAdditional', // 4. input order
+          name: 'multi-parent', // 2. extends(childValidator).properties
+          additionalProperty: 2, // 5. input order
+          thirdAdditional: 'thirdAdditional', // 6. input order
+          anything: true, // 3. (own) properties
+          id: '123', // 1. parentValidator.properties
+        })
+      ).getValue();
+      expect(Object.keys(value)).toEqual(['id', 'name', 'anything', 'firstAdditional', 'additionalProperty', 'thirdAdditional']);
+    });
+    test('custom property order', async () => {
+      const properties = {
+          optionalStrict: V.optionalStrict(V.string()),
+          optional: V.optional(V.string()),
+          required: V.string(),
+          ignore: V.ignore(),
+        };
+      const localProperties = {
+          requiredLocal: V.string(),
+          optionalLocal: V.optionalStrict(V.string()),
+        };
+      expect(Object.keys(await V.objectType().properties(properties).localProperties(localProperties)
+        .propertyOrder(['optionalStrict', 'optional'])
+        .allowAdditionalProperties(true)
+        .build()
+        .getValid({
+          ignore: 'ignore',
+          additional: 'additional',
+          requiredLocal: 'requiredLocal',
+          optional: 'optional',
+          required: 'required',
+          optionalStrict: 'optionalStrict',
+          optionalLocal: 'optionalLocal',
+        }))).toEqual(['optionalStrict', 'optional', 'required', 'requiredLocal', 'additional', 'optionalLocal'])
+    });
+    test('unknown property in propertyOrder throws', () => {
+      expect(() => V.object({ propertyOrder: ['unknown'] })).toThrow();
+    });
+    test('inherited property order', async () => {
+      expect(Object.keys(await V.objectType()
+        .extends(V.objectType().properties({ first: V.string() }).additionalPropertyOrder(['first']).build())
+        .extends(V.objectType().properties({ second: V.string() }).propertyOrder(['second']).build())
+        .properties({ third: V.optionalStrict(V.string()) })
+        .additionalPropertyOrder(['third'])
+        .build()
+        .getValid({
+          third: 'third',
+          first: 'first',
+          second: 'second',
+        }))).toEqual(['first', 'second', 'third']);
+    });
+    test('override inherited property order', async () => {
+      expect(Object.keys(await V.objectType()
+        .extends(V.objectType().properties({ first: V.optionalStrict(V.string()) }).additionalPropertyOrder(['first']).build())
+        .properties({ second: V.optionalStrict(V.string()) })
+        .allowAdditionalProperties(true)
+        .propertyOrder([])
+        .build()
+        .getValid({
+          second: 'second',
+          first: 'first',
+          additional: 'additional',
+        }))).toEqual(['second', 'first', 'additional']);
+    });
   });
 
   describe('allOf parent next validators', async () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1441,34 +1441,68 @@ describe('oneOf', () => {
   })
 });
 
+describe('allOf', () => {
+  // Other cases handled else where
+  test('throws', async () => {
+    const validator = new AllOfValidator([V.string(), new ThrowingValidator()]);
+    const result = await validator.validate('value');
+    expect(result.isSuccess()).toBe(false);
+    const violations = result.getViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toBeInstanceOf(ErrorViolation);
+  });
+
+  test('at least one validator require internally', () => expect(() => new AllOfValidator([] as any)).toThrow());
+});
+
 describe('anyOf', () => {
   enum EnumType {
     A = 'ABC',
   }
 
-  const violationHasValue = new HasValueViolation(ROOT, '2019-01-24T09:10:00Z', 'ABD');
+  const violationHasValue = new HasValueViolation(ROOT, 'ABC', 'ABD');
   const violationTypeMismatch = new TypeMismatch(ROOT, 'Date', 'ABD');
   const violationEnumMismatch = new EnumMismatch(ROOT, 'EnumType', 'ABD');
 
   const noMatchesViolations: Violation[] = [violationHasValue, violationTypeMismatch, violationEnumMismatch];
 
-  const validator = V.anyOf(V.hasValue('2019-01-24T09:10:00Z'), V.date(), V.enum(EnumType, 'EnumType'));
+  const threeOptions = V.anyOf(V.hasValue('ABC'), V.date(), V.enum(EnumType, 'EnumType'));
 
   describe('single context', () => {
-    test('valid enum', () => expectValid('ABC', validator, EnumType.A));
-    test('valid date', () => expectValid(validDateString, validator, validDate));
-    test('no matches', () => expectViolations('ABD', validator, ...noMatchesViolations));
+    test('valid value & enum', () => expectValid('ABC', threeOptions, EnumType.A));
+    test('valid date', () => expectValid(validDateString, threeOptions, validDate));
+    test('no matches', () => expectViolations('ABD', threeOptions, ...noMatchesViolations));
   });
 
+  test('at least one validator required', () => expect(() => new AnyOfValidator([])).toThrow());
+
+  test('throws', async () => {
+    const validator = V.anyOf(new ThrowingValidator());
+    const result = await validator.validate('value');
+    expect(result.isSuccess()).toBe(false);
+    const violations = result.getViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toBeInstanceOf(ErrorViolation);
+  });
+
+  describe('conflicting validators', async () => {
+    const validator = V.anyOf(V.string(), V.string().nextMap(v => v.toUpperCase()));
+
+    test('valid value', () => expectValid('ABC', validator));
+
+    test('conflicting conversions', () => expectViolations('abc', validator, new Violation(ROOT, 'ConflictingConversions', 'ABC')));
+  });
+  
   describe('array context', () => {
-    const matchingArray = ['2019-01-24T09:10:00Z', validDate, 'ABC'];
-    const arrayValidator = V.array(validator);
+    const matchingArray = [validDate, 'ABC'];
+    const arrayValidator = V.array(threeOptions);
 
     test('valid items in array', async () =>
       arrayValidator.validate(matchingArray).then(result => {
-        expect(result.getValue().length).toBe(3);
+        expect(result.getValue().length).toBe(2);
         expect(result.getViolations()).toEqual([]);
       }));
+
     test('fails due to invalid item added', async () =>
       arrayValidator.validate([...matchingArray, 'ABD']).then(result => {
         expect(result.getViolations().length).toBe(3);

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -2124,6 +2124,15 @@ describe('map function', () => {
     );
   });
 
+  test('map validation must settle when a downstream validator throws', async () => {
+    const validator = V.object({ properties: { a: V.map((value: any) => value) } }).next(new ThrowingValidator());
+
+    const result = await validator.validate({ a: 1 });
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
   test('promise throwing a ValidationError', async () => {
     await expectViolations(
       'abc',
@@ -2409,6 +2418,15 @@ describe('fn', () => {
     const result = await V.fn(() => { throw violation; }).getValid('test', { ignoreUnknownProperties: true });
     expect(result).toEqual('test');
   });
+
+  test('fn validation must settle when a downstream validator throws', async () => {
+    const validator = V.object({ properties: { a: V.fn((value: any) => value) } }).next(new ThrowingValidator());
+
+    const result = await validator.validate({ a: 1 });
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('fn2', () => {
@@ -2434,6 +2452,16 @@ describe('fn2', () => {
       expect((violation as ErrorViolation).error).toBe(error);
     }
   });
+  test('fn2 validation must settle when a downstream validator throws', async () => {
+    const validator = V.object({ properties: { a: V.fn2((value: any, _path, _ctx, success) => success(value)) } })
+      .next(new ThrowingValidator());
+
+    const result = await validator.validate({ a: 1 });
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
   test('Throws ignored violation', async () => {
     const violation = defaultViolations.unknownProperty(Path.of('foo'));
     const result = await V.fn2(() => { throw violation; }).getValid('test', { ignoreUnknownProperties: true });

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -22,6 +22,8 @@ import {
   VType,
   JsonMap,
   JsonBigInt,
+  SuccessCallback,
+  FailureCallback,
 } from './validators.js';
 import { ObjectValidator, VInheritableType } from './objectValidator.js';
 import { V } from './V.js';
@@ -976,8 +978,8 @@ describe('inheritance', () => {
     await expectViolations({}, type, defaultViolations.notNull(property('required')));
   });
 
-  describe('property order', () => {
-    test('default property order', async () => {
+  describe('propertyOrder', () => {
+    test('default propertyOrder', async () => {
       const value = (
         await multiParentChild.validate({
           firstAdditional: 'firstAdditional', // 4. input order
@@ -990,7 +992,8 @@ describe('inheritance', () => {
       ).getValue();
       expect(Object.keys(value)).toEqual(['id', 'name', 'anything', 'firstAdditional', 'additionalProperty', 'thirdAdditional']);
     });
-    test('custom property order', async () => {
+
+    test('custom propertyOrder', async () => {
       const properties = {
           optionalStrict: V.optionalStrict(V.string()),
           optional: V.optional(V.string()),
@@ -1015,10 +1018,12 @@ describe('inheritance', () => {
           optionalLocal: 'optionalLocal',
         }))).toEqual(['optionalStrict', 'optional', 'required', 'requiredLocal', 'additional', 'optionalLocal'])
     });
+
     test('unknown property in propertyOrder throws', () => {
       expect(() => V.object({ propertyOrder: ['unknown'] })).toThrow();
     });
-    test('inherited property order', async () => {
+
+    test('inherited propertyOrder', async () => {
       expect(Object.keys(await V.objectType()
         .extends(V.objectType().properties({ first: V.string() }).additionalPropertyOrder(['first']).build())
         .extends(V.objectType().properties({ second: V.string() }).propertyOrder(['second']).build())
@@ -1031,7 +1036,8 @@ describe('inheritance', () => {
           second: 'second',
         }))).toEqual(['first', 'second', 'third']);
     });
-    test('override inherited property order', async () => {
+
+    test('override inherited propertyOrder', async () => {
       expect(Object.keys(await V.objectType()
         .extends(V.objectType().properties({ first: V.optionalStrict(V.string()) }).additionalPropertyOrder(['first']).build())
         .properties({ second: V.optionalStrict(V.string()) })
@@ -1043,6 +1049,40 @@ describe('inheritance', () => {
           first: 'first',
           additional: 'additional',
         }))).toEqual(['second', 'first', 'additional']);
+    });
+
+    test('propertyOrder of localProperties is not inherited', async () => {
+      const parent = V.objectType()
+        .localProperties({ first: V.optionalStrict(V.string()) })
+        .propertyOrder(['first'])
+        .build();
+      const child = V.objectType()
+        .extends(parent)
+        .localProperties({ second: V.optionalStrict(V.string()) })
+        .build();
+      expect(child.propertyOrder).toEqual([]);
+    });
+
+    test('pick', () => expect(V.objectType()
+        .properties({ a: V.string(), b: V.string() })
+        .propertyOrder(['a', 'b'])
+        .build()
+        .pick('b')
+        .propertyOrder
+      ).toEqual(['b'])
+    );
+
+    test('omit', () => expect(V.objectType()
+        .properties({ a: V.string(), b: V.string() })
+        .propertyOrder(['a', 'b'])
+        .build()
+        .omit('a')
+        .propertyOrder
+      ).toEqual(['b'])
+    );
+
+    test('inherited functions are not allowed', () => {
+      expect(() => V.objectType().propertyOrder(['toString']).build()).toThrow();
     });
   });
 
@@ -1077,6 +1117,84 @@ describe('inheritance', () => {
       V.objectType().allowAdditionalProperties(false).build(), 
       defaultViolations.unknownPropertyDenied(ROOT.property('parentProp'))
     );
+  });
+});
+
+describe('allowsUndefined', () => {
+  const optional = V.optionalStrict(V.string());
+  const mandatory = V.string();
+
+  test('optionalStrict', () => expect(V.optionalStrict(V.string()).allowsUndefined()).toBe(true));
+  
+  test('optional', () => expect(V.optional(V.string()).allowsUndefined()).toBe(true));
+  
+  test('next', () => {
+    expect(optional.next(optional).allowsUndefined()).toBe(true);
+    expect(optional.next(mandatory).allowsUndefined()).toBe(false);
+    expect(mandatory.next(optional).allowsUndefined()).toBe(false);
+  });
+  
+  test('composition', () => {
+    expect(V.compositionOf(optional, optional, optional).allowsUndefined()).toBe(true);
+    expect(V.compositionOf(optional, optional, mandatory).allowsUndefined()).toBe(false);
+  });
+  
+  test('allOf', () => {
+    expect(V.allOf(optional, optional, optional).allowsUndefined()).toBe(true);
+    expect(V.allOf(optional, optional, mandatory).allowsUndefined()).toBe(false);
+  });
+
+  test('oneOf', () => {
+    // Only one can allow undefined for the whole validator to allow undefined!
+    expect(V.oneOf(optional, mandatory, optional).allowsUndefined()).toBe(false);
+    expect(V.oneOf(mandatory, mandatory, mandatory).allowsUndefined()).toBe(false);
+    expect(V.oneOf(mandatory, optional, mandatory).allowsUndefined()).toBe(true);
+  });
+
+  test('anyOf', () => {
+    expect(V.anyOf(mandatory, mandatory, optional).allowsUndefined()).toBe(true);
+    expect(V.anyOf(mandatory, mandatory, mandatory).allowsUndefined()).toBe(false);
+  });
+
+  describe('missing properties validation', () => {
+    class CallTraking extends Validator<any, any> {
+      public isCalled = false;
+      validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<any>, failure: FailureCallback): void {
+        this.isCalled = true;
+        success(value);
+      }
+      allowsUndefined(): boolean {
+        return true;
+      }
+    };
+    test('missing optional property is not validated when propertyOrder is defined', async () => {
+      const callTracking = new CallTraking();
+      const validator = V.objectType()
+        .properties({ optional: callTracking })
+        .propertyOrder([])
+        .build();
+      await validator.validate({});
+      expect(callTracking.isCalled).toBe(false);
+    });
+
+    test('missing optional property is validated when propertyOrder is not defined', async () => {
+      const callTracking = new CallTraking();
+      const validator = V.objectType()
+        .properties({ optional: callTracking })
+        .build();
+      await validator.validate({});
+      expect(callTracking.isCalled).toBe(true);
+    });
+
+    test('missing optional property is validated when included in propertyOrder', async () => {
+      const callTracking = new CallTraking();
+      const validator = V.objectType()
+        .properties({ optional: callTracking })
+        .propertyOrder(['optional'])
+        .build();
+      await validator.validate({});
+      expect(callTracking.isCalled).toBe(true);
+    });
   });
 });
 

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -2275,6 +2275,31 @@ describe('Set', () => {
     expect(parsedArray).toEqual(setArray);
   });
 
+  test('thrown errors', async () => {
+    const result = await V.setType(new ThrowingValidator(), false).validate(new Set([1]));
+    expect(result.isSuccess()).toBe(false);
+    const violations = result.getViolations();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toBeInstanceOf(ErrorViolation);
+  });
+
+  test('item level thrown errors are reported per item and accumulated', async () => {
+    const result = await V.setType(new ThrowingValidator(), false).validate(new Set([1, 2]));
+    expect(result.getViolations()).toEqual([
+      new ErrorViolation(Path.of(0), ThrowingValidator.error),
+      new ErrorViolation(Path.of(1), ThrowingValidator.error),
+    ]);
+  });
+
+  test('Set validation must settle when a downstream validator throws', async () => {
+    const validator = V.setType(V.any(), false).next(new ThrowingValidator());
+
+    const result = await validator.validate(new Set([1]));
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
   describe('typing', () => {
     test('JsonSet', async () => {
       const validator = V.setType(V.string(), true);

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -24,6 +24,8 @@ import {
   JsonBigInt,
   SuccessCallback,
   FailureCallback,
+  AnyOfValidator,
+  AllOfValidator,
 } from './validators.js';
 import { ObjectValidator, VInheritableType } from './objectValidator.js';
 import { V } from './V.js';
@@ -1120,40 +1122,39 @@ describe('inheritance', () => {
   });
 });
 
-describe('allowsUndefined', () => {
+describe('skipUndefined', () => {
   const optional = V.optionalStrict(V.string());
   const mandatory = V.string();
 
-  test('optionalStrict', () => expect(V.optionalStrict(V.string()).allowsUndefined()).toBe(true));
+  test('optionalStrict', () => expect(V.optionalStrict(V.string()).skipUndefined()).toBe(true));
   
-  test('optional', () => expect(V.optional(V.string()).allowsUndefined()).toBe(true));
+  test('optional', () => expect(V.optional(V.string()).skipUndefined()).toBe(true));
   
   test('next', () => {
-    expect(optional.next(optional).allowsUndefined()).toBe(true);
-    expect(optional.next(mandatory).allowsUndefined()).toBe(false);
-    expect(mandatory.next(optional).allowsUndefined()).toBe(false);
+    expect(optional.next(optional).skipUndefined()).toBe(true);
+    expect(optional.next(mandatory).skipUndefined()).toBe(false);
+    expect(mandatory.next(optional).skipUndefined()).toBe(false);
   });
   
   test('composition', () => {
-    expect(V.compositionOf(optional, optional, optional).allowsUndefined()).toBe(true);
-    expect(V.compositionOf(optional, optional, mandatory).allowsUndefined()).toBe(false);
+    expect(V.compositionOf(optional, optional, optional).skipUndefined()).toBe(true);
+    expect(V.compositionOf(optional, optional, mandatory).skipUndefined()).toBe(false);
   });
   
   test('allOf', () => {
-    expect(V.allOf(optional, optional, optional).allowsUndefined()).toBe(true);
-    expect(V.allOf(optional, optional, mandatory).allowsUndefined()).toBe(false);
+    expect(V.allOf(optional, optional, optional).skipUndefined()).toBe(true);
+    expect(V.allOf(optional, optional, mandatory).skipUndefined()).toBe(false);
   });
 
   test('oneOf', () => {
-    // Only one can allow undefined for the whole validator to allow undefined!
-    expect(V.oneOf(optional, mandatory, optional).allowsUndefined()).toBe(false);
-    expect(V.oneOf(mandatory, mandatory, mandatory).allowsUndefined()).toBe(false);
-    expect(V.oneOf(mandatory, optional, mandatory).allowsUndefined()).toBe(true);
+    expect(V.oneOf(optional, mandatory, optional).skipUndefined()).toBe(false);
+    expect(V.oneOf(mandatory, mandatory, mandatory).skipUndefined()).toBe(false);
+    expect(V.oneOf(V.nullTo('value'), optional, mandatory).skipUndefined()).toBe(false);
   });
 
   test('anyOf', () => {
-    expect(V.anyOf(mandatory, mandatory, optional).allowsUndefined()).toBe(true);
-    expect(V.anyOf(mandatory, mandatory, mandatory).allowsUndefined()).toBe(false);
+    expect(V.anyOf(mandatory, mandatory, optional).skipUndefined()).toBe(false);
+    expect(V.anyOf(mandatory, mandatory, mandatory).skipUndefined()).toBe(false);
   });
 
   describe('missing properties validation', () => {
@@ -1163,7 +1164,7 @@ describe('allowsUndefined', () => {
         this.isCalled = true;
         success(value);
       }
-      allowsUndefined(): boolean {
+      skipUndefined(): boolean {
         return true;
       }
     };

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1553,7 +1553,7 @@ describe('anyOf', () => {
 
     test('valid value', () => expectValid('ABC', validator));
 
-    test('conflicting conversions', () => expectViolations('abc', validator, new Violation(ROOT, 'ConflictingConversions', 'abc')));
+    test('conflicting conversions', () => expectViolations('abc', validator, new Violation(ROOT, 'ConflictingConversions', ['abc', 'ABC'])));
   });
   
   describe('array context', () => {
@@ -1815,7 +1815,7 @@ describe('async validation', () => {
 
     test('results must match', async () => {
       const validator = V.allOf(V.string(), V.toInteger());
-      await expectViolations('123', validator, new Violation(ROOT, 'ConflictingConversions', '123'));
+      await expectViolations('123', validator, new Violation(ROOT, 'ConflictingConversions', ['123', 123]));
     });
 
     test('return original', async () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -89,6 +89,16 @@ class ThrowingValidator extends Validator<string> {
   }
 };
 
+/**
+ * Reports success from a microtask, i.e. after the caller's synchronous scope has already exited.
+ * Unlike `defer`, this overrides `validatePathV2` directly, so no promise bridge is involved.
+ */
+class AsyncValidator extends Validator<any> {
+  validatePathV2(value: any, path: Path, ctx: ValidationContext, success: (value: any) => void, failure: (violations: Violation[]) => void): void {
+    Promise.resolve().then(() => success(value));
+  }
+};
+
 describe('ValidationResult', () => {
   test('getValue() returns valid value', async () => {
     const result = await V.string().validate('123');
@@ -918,6 +928,24 @@ describe('objects', () => {
       expect(result.isSuccess()).toBe(false);
       expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
     }, 1000);
+
+    test('object validation must settle when a downstream validator throws after an async property', async () => {
+      const validator = V.object({ properties: { a: defer(V.any()) } }).next(new ThrowingValidator());
+
+      const result = await validator.validate({ a: 1 });
+
+      expect(result.isSuccess()).toBe(false);
+      expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+    }, 1000);
+
+    test('object validation must settle when a downstream validator throws after a microtask success', async () => {
+      const validator = V.object({ properties: { a: new AsyncValidator() } }).next(new ThrowingValidator());
+
+      const result = await validator.validate({ a: 1 });
+
+      expect(result.isSuccess()).toBe(false);
+      expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+    }, 1000);
   });
 });
 
@@ -1479,6 +1507,15 @@ describe('allOf', () => {
     expect(result.isSuccess()).toBe(false);
     expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
   }, 1000);
+
+  test('allOf validation must settle when a downstream validator throws after an async branch', async () => {
+    const validator = V.allOf(defer(V.any()), V.any()).next(new ThrowingValidator());
+
+    const result = await validator.validate('value');
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('anyOf', () => {
@@ -1537,6 +1574,15 @@ describe('anyOf', () => {
 
   test('anyOf validation must settle when a downstream validator throws', async () => {
     const validator = V.anyOf(V.any(), V.any()).next(new ThrowingValidator());
+
+    const result = await validator.validate('value');
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
+  test('anyOf validation must settle when a downstream validator throws after an async branch', async () => {
+    const validator = V.anyOf(defer(V.any()), V.any()).next(new ThrowingValidator());
 
     const result = await validator.validate('value');
 
@@ -1611,6 +1657,15 @@ describe('arrays', () => {
     const validator = V.array(V.any()).next(new ThrowingValidator());
 
     const result = await validator.validate([1]);
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
+  test('array validation must settle when a downstream validator throws after an async item', async () => {
+    const validator = V.array(defer(V.any())).next(new ThrowingValidator());
+
+    const result = await validator.validate([1, 2, 3]);
 
     expect(result.isSuccess()).toBe(false);
     expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
@@ -2133,6 +2188,15 @@ describe('map function', () => {
     expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
   }, 1000);
 
+  test('map validation must settle when a downstream validator throws after an async mapping function', async () => {
+    const validator = V.object({ properties: { a: V.map(async (value: any) => value) } }).next(new ThrowingValidator());
+
+    const result = await validator.validate({ a: 1 });
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
   test('promise throwing a ValidationError', async () => {
     await expectViolations(
       'abc',
@@ -2258,6 +2322,15 @@ describe('Map', () => {
     expect(result.isSuccess()).toBe(false);
     expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
   }, 1000);
+
+  test('Map validation must settle when a downstream validator throws after an async entry', async () => {
+    const validator = V.mapType(defer(V.any()), defer(V.any()), false).next(new ThrowingValidator());
+
+    const result = await validator.validate(new Map([['key', 'value']]));
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('Set', () => {
@@ -2304,6 +2377,15 @@ describe('Set', () => {
     const validator = V.setType(V.any(), false).next(new ThrowingValidator());
 
     const result = await validator.validate(new Set([1]));
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
+  test('Set validation must settle when a downstream validator throws after an async item', async () => {
+    const validator = V.setType(defer(V.any()), false).next(new ThrowingValidator());
+
+    const result = await validator.validate(new Set([1, 2]));
 
     expect(result.isSuccess()).toBe(false);
     expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
@@ -2427,6 +2509,15 @@ describe('fn', () => {
     expect(result.isSuccess()).toBe(false);
     expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
   }, 1000);
+
+  test('fn validation must settle when a downstream validator throws after an async function', async () => {
+    const validator = V.object({ properties: { a: V.fn(async (value: any) => value) } }).next(new ThrowingValidator());
+
+    const result = await validator.validate({ a: 1 });
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('fn2', () => {
@@ -2455,6 +2546,17 @@ describe('fn2', () => {
   test('fn2 validation must settle when a downstream validator throws', async () => {
     const validator = V.object({ properties: { a: V.fn2((value: any, _path, _ctx, success) => success(value)) } })
       .next(new ThrowingValidator());
+
+    const result = await validator.validate({ a: 1 });
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
+
+  test('fn2 validation must settle when a downstream validator throws after an async success', async () => {
+    const validator = V.object({
+      properties: { a: V.fn2((value: any, _path, _ctx, success) => { Promise.resolve().then(() => success(value)); }) },
+    }).next(new ThrowingValidator());
 
     const result = await validator.validate({ a: 1 });
 

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -1553,7 +1553,7 @@ describe('anyOf', () => {
 
     test('valid value', () => expectValid('ABC', validator));
 
-    test('conflicting conversions', () => expectViolations('abc', validator, new Violation(ROOT, 'ConflictingConversions', 'ABC')));
+    test('conflicting conversions', () => expectViolations('abc', validator, new Violation(ROOT, 'ConflictingConversions', 'abc')));
   });
   
   describe('array context', () => {

--- a/packages/core/src/V.spec.ts
+++ b/packages/core/src/V.spec.ts
@@ -128,11 +128,19 @@ describe('getValid', () => {
   });
 })
 
-test('assertTrue', () =>
-  expectValid(
-    true,
-    V.assertTrue(value => value === true),
-  ));
+describe('assertTrue', () => {
+  test('valid case', () =>
+    expectValid(
+      true,
+      V.assertTrue(value => value === true),
+    ));
+
+  test('throwing function', () => 
+    expectViolations('any', V.assertTrue(() => { throw new Error('boom'); }), new ErrorViolation(ROOT, new Error('boom'))));
+
+  test('throwing from sub path', () => 
+    expectViolations('any', V.assertTrue(() => { throw new Error('boom'); }, 'BadNested', Path.of('nested')), new ErrorViolation(Path.of('nested'), new Error('boom'))));
+});
 
 describe('strings', () => {
   test('valid value', () => expectValid('str', V.string()));
@@ -901,6 +909,15 @@ describe('objects', () => {
         new ErrorViolation(property('additional'), ThrowingValidator.error),
       ]);
     });
+
+    test('object validation must settle when a downstream validator throws', async () => {
+      const validator = V.object({ properties: { a: V.any() } }).next(new ThrowingValidator());
+
+      const result = await validator.validate({ a: 1 });
+
+      expect(result.isSuccess()).toBe(false);
+      expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+    }, 1000);
   });
 });
 
@@ -1453,6 +1470,15 @@ describe('allOf', () => {
   });
 
   test('at least one validator require internally', () => expect(() => new AllOfValidator([] as any)).toThrow());
+
+  test('allOf validation must settle when a downstream validator throws', async () => {
+    const validator = V.allOf(V.any(), V.any()).next(new ThrowingValidator());
+
+    const result = await validator.validate('value');
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('anyOf', () => {
@@ -1508,6 +1534,15 @@ describe('anyOf', () => {
         expect(result.getViolations().length).toBe(3);
       }));
   });
+
+  test('anyOf validation must settle when a downstream validator throws', async () => {
+    const validator = V.anyOf(V.any(), V.any()).next(new ThrowingValidator());
+
+    const result = await validator.validate('value');
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('arrays', () => {
@@ -1571,6 +1606,15 @@ describe('arrays', () => {
     expect(violations).toHaveLength(1);
     expect(violations[0]).toBeInstanceOf(ErrorViolation);
   });
+
+  test('array validation must settle when a downstream validator throws', async () => {
+    const validator = V.array(V.any()).next(new ThrowingValidator());
+
+    const result = await validator.validate([1]);
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('number', () => {
@@ -2196,6 +2240,15 @@ describe('Map', () => {
     expect(violations[0]).toBeInstanceOf(ErrorViolation);
     expect(violations[1]).toBeInstanceOf(ErrorViolation);
   });
+
+  test('Map validation must settle when a downstream validator throws', async () => {
+    const validator = V.mapType(V.any(), V.any(), false).next(new ThrowingValidator());
+
+    const result = await validator.validate(new Map([['key', 'value']]));
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result.getViolations().map(v => v.type)).toEqual(['Error']);
+  }, 1000);
 });
 
 describe('Set', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './objectValidator.js';
 export * from './objectValidatorBuilder.js';
 export * from './typing.js';
 export * from './schema.js';
+export * from './warnLogger.js';

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -81,6 +81,11 @@ export interface ObjectModel<LocalType = unknown, InheritableType = unknown> {
    * 
    * For optimal performance it is recommended to define at least an empty array for `propertyOrder`. 
    * That way missing optional properties are skipped entirely. 
+   * 
+   * NOTE: `propertyOrder` is **not** inherited via `ObjectModel.extends`. This is to allow full control
+   * of the property ordering in the child model. Please use `V.objectType()` which by default inherits
+   * the `propertyOrder` from the parent model, but also allows overriding it in the child model. `V.objectType()`
+   * also allows finer control over the order in which inherited vs own properties are ordered. 
    */
   readonly propertyOrder?: string[];
 }
@@ -188,7 +193,7 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
         }
       });
       const registerMandatoryProperty = ([key, validator]: [string, Validator<unknown, unknown>]) => {
-        if (!validator.allowsUndefined()) {
+        if (!validator.skipUndefined()) {
           validationOrder.add(key);
         }
       };

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -268,8 +268,8 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
     const validateProperty = (key: string, propertyValue: unknown, propertyPath: Path) => {
       this.properties[key].validatePathV2(propertyValue, propertyPath, ctx,
         (result) => {
-          if (this.localProperties[key]) {
-            validateLocalProperty(key, propertyValue, propertyPath);
+          if (Object.hasOwn(this.localProperties, key)) {
+            validateLocalProperty(key, result, propertyPath);
           } else {
             reportSuccess(key, result);
           }
@@ -342,7 +342,7 @@ function pick(properties: Properties, fn: (key: keyof any) => boolean): Properti
 export function mergeProperties(from: Properties, to: Properties): Properties {
   if (from) {
     for (const key in from) {
-      if (to[key]) {
+      if (Object.hasOwn(to, key)) {
         to[key] = to[key].next(from[key]);
       } else {
         to[key] = from[key];

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -16,7 +16,7 @@ import {
   ValidatorFnWrapperV2,
   Violation,
   violationsOf,
-} from "./validators";
+} from "./validators.js";
 
 export type PropertyModel = { [s: string]: string | number | Validator };
 

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -29,10 +29,6 @@ export interface MapEntryModel<K = unknown, V = unknown> {
   readonly values: Validator<V>;
 }
 
-export interface PropertyFilter {
-  (key: string): boolean;
-}
-
 export type VInheritableType<V extends ObjectValidator<any, any>> = V extends ObjectValidator<any, infer Out> ? Out : unknown;
 
 export interface ObjectModel<LocalType = unknown, InheritableType = unknown> {

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -230,8 +230,11 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
       return success(convertedObject as LocalType);
     }
 
+    let done = false;
+
     const reportResult = () => {
       if (--expectedResponses === 0) {
+        done = true;
         if (violations.length > 0) {
           failure(violations);
         } else {
@@ -308,14 +311,18 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
       const valuePath = path.property(key);
       const propertyValue = anyValue[key];
       try {
-        if (this.properties[key]) {
+        if (Object.hasOwn(this.properties, key)) {
           validateProperty(key, propertyValue, valuePath);
-        } else if (this.localProperties[key]) {
+        } else if (Object.hasOwn(this.localProperties, key)) {
           validateLocalProperty(key, propertyValue, valuePath);
         } else {
           validateAdditionalProperty(key, propertyValue, valuePath, 0, 0);
         }
       } catch (error) {
+        if (done) {
+          // Already reported: the throw came from downstream, not from this property.
+          throw error;
+        }
         reportFailure(key, error);
       }
     }

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -63,6 +63,26 @@ export interface ObjectModel<LocalType = unknown, InheritableType = unknown> {
    * Local, non-inheritable rules. 
    */
   readonly localNext?: Validator | Validator[];
+  /**
+   * Output property ordering:
+   * 
+   * Default is `undefined` (for backwards compatibility), which means that properties will be ordered in 
+   * 1) inherited properties first in inheritance order,
+   * 2) properties
+   * 3) localProperties
+   * 4) additionalProperties in input order.
+   * 
+   * If `propertyOrder` is defined, output properties will be ordered in
+   * 1) propertyOrder
+   * 2) inherited mandatory properties in inheritance order
+   * 3) mandatory properties
+   * 4) mandatory localProperties
+   * 5) optional and additionalProperties in input order.
+   * 
+   * For optimal performance it is recommended to define at least an empty array for `propertyOrder`. 
+   * That way missing optional properties are skipped entirely. 
+   */
+  readonly propertyOrder?: string[];
 }
 
 export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, In = unknown> extends Validator<LocalType, In> {
@@ -75,6 +95,8 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
   public readonly parentValidators: ObjectValidator[];
 
   public readonly nextValidator?: Validator;
+
+  public readonly propertyOrder?: string[];
 
   private readonly validator: Validator<LocalType, In>;
 
@@ -103,8 +125,9 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     this.additionalProperties = additionalProperties.concat(getMapEntryValidators(model.additionalProperties));
     this.properties = mergeProperties(getPropertyValidators(model.properties), properties);
     this.localProperties = getPropertyValidators(model.localProperties);
+    this.propertyOrder = model.propertyOrder;
 
-    let validator: Validator = new PropertiesValidator<LocalType, In>(this.properties, this.localProperties, this.additionalProperties);
+    let validator: Validator = new PropertiesValidator<LocalType, In>(this.properties, this.localProperties, this.additionalProperties, this.propertyOrder);
     const next = nextValidators.length > 0 ? maybeCompositionOf(...(nextValidators as CompositionParameters)) : undefined;
     if (next) {
       this.nextValidator = next;
@@ -122,6 +145,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
       }
     }
     this.validator = validator as Validator<LocalType, In>;
+    Object.freeze(this.propertyOrder);
     Object.freeze(this.parentValidators);
     Object.freeze(this);
   }
@@ -146,11 +170,35 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
 }
 
 export class PropertiesValidator<LocalType = unknown, In = unknown> extends Validator<LocalType, In> {
-  constructor(readonly properties: Properties, readonly localProperties: Properties, readonly additionalProperties: MapEntryValidator[]) {
+  private readonly validationOrder: string[];
+  constructor(readonly properties: Properties, readonly localProperties: Properties, readonly additionalProperties: MapEntryValidator[], propertyOrder?: string[]) {
     super();
+    const validationOrder: Set<string> = new Set();
+    if (propertyOrder === undefined) {
+      Object.keys(properties).forEach(key => validationOrder.add(key));
+      Object.keys(localProperties).forEach(key => validationOrder.add(key));
+    } else {
+      propertyOrder.forEach(key => {
+        if (properties[key] || localProperties[key]) {
+          validationOrder.add(key);
+        } else {
+          throw new Error(`Unknown property: '${key}'`);
+        }
+      });
+      const registerMandatoryProperty = ([key, validator]: [string, Validator<unknown, unknown>]) => {
+        if (!validator.allowsUndefined) {
+          validationOrder.add(key);
+        }
+      };
+      Object.entries(properties).forEach(registerMandatoryProperty);
+      Object.entries(localProperties).forEach(registerMandatoryProperty);
+    }
+    this.validationOrder = Array.from(validationOrder);
+
     Object.freeze(this.properties);
     Object.freeze(this.localProperties);
     Object.freeze(this.additionalProperties);
+    Object.freeze(this.validationOrder);
     Object.freeze(this);
   }
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<LocalType>, failure: FailureCallback): void {
@@ -164,7 +212,7 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
     const convertedObject: any = {} as LocalType;
     let violations: Violation[] = [];
     
-    const keys = new Set<string>([...Object.keys(this.properties), ...Object.keys(this.localProperties)]);
+    const keys = new Set<string>(this.validationOrder);
     // Add all, including inherited keys
     for (const key in anyValue) {
       keys.add(key);

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -230,11 +230,8 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
       return success(convertedObject as LocalType);
     }
 
-    let done = false;
-
     const reportResult = () => {
       if (--expectedResponses === 0) {
-        done = true;
         if (violations.length > 0) {
           failure(violations);
         } else {
@@ -319,10 +316,6 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
           validateAdditionalProperty(key, propertyValue, valuePath, 0, 0);
         }
       } catch (error) {
-        if (done) {
-          // Already reported: the throw came from downstream, not from this property.
-          throw error;
-        }
         reportFailure(key, error);
       }
     }

--- a/packages/core/src/objectValidator.ts
+++ b/packages/core/src/objectValidator.ts
@@ -125,7 +125,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     this.additionalProperties = additionalProperties.concat(getMapEntryValidators(model.additionalProperties));
     this.properties = mergeProperties(getPropertyValidators(model.properties), properties);
     this.localProperties = getPropertyValidators(model.localProperties);
-    this.propertyOrder = model.propertyOrder;
+    this.propertyOrder = model.propertyOrder ? [...model.propertyOrder] : undefined;
 
     let validator: Validator = new PropertiesValidator<LocalType, In>(this.properties, this.localProperties, this.additionalProperties, this.propertyOrder);
     const next = nextValidators.length > 0 ? maybeCompositionOf(...(nextValidators as CompositionParameters)) : undefined;
@@ -158,6 +158,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     return new ObjectValidator<Omit<LocalType, K extends keyof LocalType ? K : never>, Omit<InheritableType, K extends keyof InheritableType ? K : never>>({
       properties: pick(this.properties, key => !keys.includes(key as any)),
       localProperties: pick(this.localProperties, key => !keys.includes(key as any)),
+      propertyOrder: this.propertyOrder?.filter(key => !keys.includes(key as any)),
     });
   }
 
@@ -165,6 +166,7 @@ export class ObjectValidator<LocalType = unknown, InheritableType = LocalType, I
     return new ObjectValidator<Pick<LocalType, K extends keyof LocalType ? K : never>, Pick<InheritableType, K extends keyof InheritableType ? K : never>>({
       properties: pick(this.properties, key => keys.includes(key as any)),
       localProperties: pick(this.localProperties, key => keys.includes(key as any)),
+      propertyOrder: this.propertyOrder?.filter(key => keys.includes(key as any)),
     });
   }
 }
@@ -179,14 +181,14 @@ export class PropertiesValidator<LocalType = unknown, In = unknown> extends Vali
       Object.keys(localProperties).forEach(key => validationOrder.add(key));
     } else {
       propertyOrder.forEach(key => {
-        if (properties[key] || localProperties[key]) {
+        if (Object.hasOwn(properties, key) || Object.hasOwn(localProperties, key)) {
           validationOrder.add(key);
         } else {
           throw new Error(`Unknown property: '${key}'`);
         }
       });
       const registerMandatoryProperty = ([key, validator]: [string, Validator<unknown, unknown>]) => {
-        if (!validator.allowsUndefined) {
+        if (!validator.allowsUndefined()) {
           validationOrder.add(key);
         }
       };

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -22,7 +22,7 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
    */
   extends<X>(parent: ObjectValidator<any, X>) {
     this._extends.push(parent);
-      if (parent.propertyOrder) {
+    if (parent.propertyOrder) {
       if (this._propertyOrder === undefined) {
         this._propertyOrder = inheritablePropertyOrder(parent);
       } else {

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -14,9 +14,8 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
   constructor() {}
   /**
    * Extends the current object validator with the properties and additional properties of the given parent validator.
-   * The property order of the parent validator will be merged with the current property order, if defined.
-   * The order in which `extends` and `propertyOrder` are called matters. The property order of the parent validator will 
-   * be merged with the current property order in the order in which extends is called.
+   * The property order of the parent validator will be merged with the current property order.
+   * The order in which `extends`, `propertyOrder` and `additionalPropertyOrder` are called matters!
    * 
    * @param parent 
    * @returns 

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -102,6 +102,6 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
   }
 };
 
-function inheritablePropertyOrder(parent: ObjectValidator<any, any>) {
+export function inheritablePropertyOrder(parent: ObjectValidator<any, any>) {
   return parent.propertyOrder!.filter((key) => Object.hasOwn(parent.properties, key));
 }

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -10,9 +10,15 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
   private _additionalProperties: MapEntryModel[] = [];
   private _next?: Validator[] = [];
   private _localNext?: Validator[] = [];
+  private _propertyOrder: undefined | string[];
   constructor() {}
   extends<X>(parent: ObjectValidator<any, X>) {
     this._extends.push(parent);
+    if (this._propertyOrder === undefined) {
+      this._propertyOrder = parent.propertyOrder;
+    } else if (parent.propertyOrder !== undefined) {
+      this._propertyOrder = [...this._propertyOrder, ...parent.propertyOrder];
+    }
     return this as ObjectValidatorBuilder<Props & X, Next, LocalProps, LocalNext>;
   }
   properties<X>(properties: { [K in keyof X]: Validator<X[K]> }) {
@@ -46,6 +52,18 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
     this._localNext?.push(validator);
     return this as unknown as ObjectValidatorBuilder<Props, Next, LocalProps, NextOut>;
   }
+  propertyOrder(propertyOrder: undefined | string[]) {
+    this._propertyOrder = propertyOrder;
+    return this;
+  }
+  additionalPropertyOrder(propertyOrder: string[]) {
+    if (this._propertyOrder === undefined) {
+      this._propertyOrder = propertyOrder;
+    } else {
+      this._propertyOrder = [...this._propertyOrder, ...propertyOrder];
+    }
+    return this;
+  }
   build() {
     return new ObjectValidator<
         (Next extends {} ? Next : Props) & (LocalNext extends {} ? LocalNext : LocalProps), 
@@ -57,6 +75,7 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
       next: this._next,
       localProperties: this._localProperties,
       localNext: this._localNext,
+      propertyOrder: this._propertyOrder,
     });
   }
 };

--- a/packages/core/src/objectValidatorBuilder.ts
+++ b/packages/core/src/objectValidatorBuilder.ts
@@ -12,12 +12,23 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
   private _localNext?: Validator[] = [];
   private _propertyOrder: undefined | string[];
   constructor() {}
+  /**
+   * Extends the current object validator with the properties and additional properties of the given parent validator.
+   * The property order of the parent validator will be merged with the current property order, if defined.
+   * The order in which `extends` and `propertyOrder` are called matters. The property order of the parent validator will 
+   * be merged with the current property order in the order in which extends is called.
+   * 
+   * @param parent 
+   * @returns 
+   */
   extends<X>(parent: ObjectValidator<any, X>) {
     this._extends.push(parent);
-    if (this._propertyOrder === undefined) {
-      this._propertyOrder = parent.propertyOrder;
-    } else if (parent.propertyOrder !== undefined) {
-      this._propertyOrder = [...this._propertyOrder, ...parent.propertyOrder];
+      if (parent.propertyOrder) {
+      if (this._propertyOrder === undefined) {
+        this._propertyOrder = inheritablePropertyOrder(parent);
+      } else {
+        this._propertyOrder = [...this._propertyOrder, ...inheritablePropertyOrder(parent)];
+      }
     }
     return this as ObjectValidatorBuilder<Props & X, Next, LocalProps, LocalNext>;
   }
@@ -52,10 +63,22 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
     this._localNext?.push(validator);
     return this as unknown as ObjectValidatorBuilder<Props, Next, LocalProps, NextOut>;
   }
+  /**
+   * Override possibly inherited property order.
+   * 
+   * @param propertyOrder 
+   * @returns 
+   */
   propertyOrder(propertyOrder: undefined | string[]) {
     this._propertyOrder = propertyOrder;
     return this;
   }
+  /**
+   * Append to possibly inherited property order.
+   * 
+   * @param propertyOrder 
+   * @returns 
+   */
   additionalPropertyOrder(propertyOrder: string[]) {
     if (this._propertyOrder === undefined) {
       this._propertyOrder = propertyOrder;
@@ -79,3 +102,7 @@ export class ObjectValidatorBuilder<Props, Next, LocalProps, LocalNext> {
     });
   }
 };
+
+function inheritablePropertyOrder(parent: ObjectValidator<any, any>) {
+  return parent.propertyOrder!.filter((key) => Object.hasOwn(parent.properties, key));
+}

--- a/packages/core/src/schema.spec.ts
+++ b/packages/core/src/schema.spec.ts
@@ -129,7 +129,7 @@ describe('schema', () => {
     test('new proxies cannot be created after constructor is finished', () =>
       expect(() => new SchemaValidator(schema => ({ discriminator: 'type', models: {} })).of('NewModel')).toThrow());
 
-    test('property order', async () => {
+    test('default property order', async () => {
       const value = (
         await schema.validate({
           property: 'property',
@@ -143,6 +143,44 @@ describe('schema', () => {
       ).getValue() as any;
       expect(Object.keys(value)).toEqual(['type', 'extends', 'properties', 'property']);
       expect(Object.keys(value.properties)).toEqual(['first', 'second']);
+    });
+
+    test('custom property order', async () => {
+      const schemaWithOrder = new SchemaValidator(schema => ({
+        discriminator: 'type',
+        models: {
+          Parent: {
+            properties: {
+              type: V.string(),
+              first: V.string(),
+              second: V.string(),
+            },
+            propertyOrder: ['type', 'second', 'first'],
+          },
+          Child: {
+            extends: 'Parent',
+            properties: {
+              third: V.string(),
+            },
+            propertyOrder: ['third', 'second', 'first'],
+          },
+        },
+      }));
+
+      const parentValue = await schemaWithOrder.getValid({
+        first: 'first',
+        type: 'Parent',
+        second: 'second',
+      }) as any;
+      expect(Object.keys(parentValue)).toEqual(['type', 'second', 'first']);  
+
+      const childValue = await schemaWithOrder.getValid({
+        type: 'Child',
+        first: 'first',
+        third: 'third',
+        second: 'second',
+      }) as any;
+      expect(Object.keys(childValue)).toEqual(['third', 'second', 'first', 'type']);
     });
   });
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -36,6 +36,14 @@ export interface ClassModel {
   readonly additionalProperties?: boolean | MapEntryModel | MapEntryModel[];
   readonly next?: Validator;
   readonly localNext?: Validator;
+  /**
+   * The order in which properties should be validated. If not specified, the order is undefined.
+   * NOTE: This property is not inherited automatically from parent classes. If you want to 
+   * inherit the property order, you must explicitly specify it in the child class.
+   * 
+   * Consider using `V.objectType().propertyOrder(...)` to define the property order in a class model.
+   */
+  readonly propertyOrder?: string[];
 }
 
 export class ModelRef extends Validator {
@@ -173,6 +181,7 @@ export class SchemaValidator extends Validator {
         localProperties,
         next: classModel.next,
         localNext: classModel.localNext,
+        propertyOrder: classModel.propertyOrder,
       };
       validator = new ObjectValidator(model);
     }

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -379,10 +379,8 @@ export class ValidatorFnWrapper<Out = unknown, In = unknown> extends Validator<O
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
-    let done = false;
     try {
       const maybePromise = this.fn(value, path, ctx);
-      done = true;
       if (isPromise(maybePromise)) {
         maybePromise.then(
           success,
@@ -392,10 +390,6 @@ export class ValidatorFnWrapper<Out = unknown, In = unknown> extends Validator<O
         success(maybePromise);
       }
     } catch (error) {
-      if (done) {
-        // Already handed off: the throw came from downstream, not from the validator function.
-        throw error;
-      }
       ctx.failureV2(violationsOf(error, path), value, success, failure);
     }
   }
@@ -408,22 +402,15 @@ export class ValidatorFnWrapperV2<Out = unknown, In = unknown> extends Validator
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
-    let done = false;
     try {
       this.fn(value, path, ctx,
         (result) => {
-          done = true;
           success(result);
         },
         error => {
-          done = true;
           ctx.failureV2(error, value, success, failure);
         });
     } catch (error) {
-      if (done) {
-        // Already reported: the throw came from downstream, not from the validator function.
-        throw error;
-      }
       ctx.failureV2(violationsOf(error, path), value, success, failure);
     }
   }
@@ -448,11 +435,9 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
     }
     let expectedResponses = value.length;
     let violations: Violation[] = [];
-    let done = false;
 
     const reportResult = () => {
       if (--expectedResponses === 0) {
-        done = true;
         if (violations.length > 0) {
           failure(violations);
         } else {
@@ -475,10 +460,6 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
             reportResult();
           });
       } catch (error) {
-        if (done) {
-          // Already reported: the throw came from downstream, not from this item.
-          throw error;
-        }
         violations = violations.concat(violationsOf(error, itemPath));
         reportResult();
       }
@@ -534,11 +515,18 @@ export class CompositionValidator<Out = unknown, In = any> extends CompositeVali
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     const validateNext = (index: number, currentValue: any) => {
       if (index < this.validators.length) {
-        this.validators[index].validatePathV2(currentValue, path, ctx,
-          (result) => validateNext(index + 1, result),
-          (error) => failure(violationsOf(error, path))
-        );
+        try {
+          this.validators[index].validatePathV2(currentValue, path, ctx,
+            (result) => validateNext(index + 1, result),
+            (error) => failure(violationsOf(error, path))
+          );
+        } catch (error) {
+          // A validator in the chain threw. Report it here rather than letting it unwind
+          // into an upstream validator that has already reported its own result.
+          failure(violationsOf(error, path));
+        }
       } else {
+        // NOTE: outside the try - a throw from here belongs to the caller's continuation.
         success(currentValue);
       }
     }
@@ -605,7 +593,6 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
     let foundMatch = false;
     let convertedValue: any;
     let expectedResponses = this.validators.length;
-    let done = false;
 
     const reportResult = (result: undefined | Out, error: any) => {
       if (error) {
@@ -617,7 +604,6 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
         conversionViolation = new Violation(path, 'ConflictingConversions', result);
       }
       if (--expectedResponses === 0) {
-        done = true;
         if (conversionViolation) {
           failure([conversionViolation]);
         } else if (foundMatch) {
@@ -637,10 +623,6 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
           (error) => reportResult(undefined, error)
         );
       } catch (error) {
-        if (done) {
-          // Already reported: the throw came from downstream, not from this validator.
-          throw error;
-        }
         reportResult(undefined, error);
       }
     }
@@ -788,10 +770,8 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
     let violations: Violation[] = [];
     const entries: [K, V][] = [];
     let expectedResponses = map.size * 2;
-    let done = false;
 
     const reportResult = () => {
-      done = true;
       if (violations.length > 0) {
         failure(violations);
       } else {
@@ -825,8 +805,6 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
           (error) => reportEntry(entryIndex, 0, undefined, error)
         );
       } catch (error) {
-        // No `done` check needed: within an entry the key is always reported before the
-        // value, so the last response is always a value and `done` cannot be set here.
         reportEntry(entryIndex, 0, undefined, error);
       }
       try {
@@ -835,10 +813,6 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
           (error) => reportEntry(entryIndex, 1, undefined, error)
         );
       } catch (error) {
-        if (done) {
-          // Already reported: the throw came from downstream, not from this value.
-          throw error;
-        }
         reportEntry(entryIndex, 1, undefined, error);
       }
     }
@@ -902,10 +876,8 @@ export class SetValidator<T = unknown, E extends boolean = true> extends Validat
     const items: T[] = [];
     let violations: Violation[] = [];
     let expectedResponses = (value instanceof Set ? value.size : value.length);
-    let done = false;
 
     const reportResult = () => {
-      done = true;
       if (violations.length > 0) {
         failure(violations);
       } else {
@@ -937,10 +909,6 @@ export class SetValidator<T = unknown, E extends boolean = true> extends Validat
           (error) => reportItem(index, undefined, error)
         );
       } catch (error) {
-        if (done) {
-          // Already reported: the throw came from downstream, not from this item.
-          throw error;
-        }
         reportItem(index, undefined, error);
       }
     }
@@ -1452,7 +1420,6 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
     let firstResult = true;
     let convertedValue: any;
     let expectedResponses = this.validators.length;
-    let done = false;
 
     const reportResult = (result: undefined | Out, error: any) => {
       if (error) {
@@ -1464,7 +1431,6 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
         violations.push(new Violation(path, 'ConflictingConversions', value));
       }
       if (--expectedResponses === 0) {
-        done = true;
         if (violations.length > 0) {
           failure(violations);
         } else {
@@ -1484,10 +1450,6 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
           (error) => reportResult(undefined, error)
         );
       } catch (error) {
-        if (done) {
-          // Already reported: the throw came from downstream, not from this validator.
-          throw error;
-        }
         reportResult(undefined, error);
       }
     }
@@ -1643,10 +1605,7 @@ export class ValueMapper<Out = unknown, In = unknown> extends Validator<Out, In>
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
-    let done = false;
-
     const handleResult = (result: any) => {
-      done = true;
       if (result instanceof Violation) {
         ctx.failureV2(result, value, success, failure);
       } else {
@@ -1665,10 +1624,6 @@ export class ValueMapper<Out = unknown, In = unknown> extends Validator<Out, In>
         handleResult(maybePromise);
       }
     } catch (error) {
-      if (done) {
-        // Already reported: the throw came from downstream, not from the mapping function.
-        throw error;
-      }
       failure(violationsOf(error, path));
     }
   }

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -62,6 +62,8 @@ export interface FailureCallback {
 }
 
 export abstract class Validator<Out = unknown, In = unknown> {
+  constructor(public readonly allowsUndefined: boolean = false) {}
+
   validateGroup(value: In, group: Group): Promise<ValidationResult<Out>> {
     return this.validate(value, { group });
   }
@@ -1441,7 +1443,7 @@ export class PatternNormalizer extends PatternValidator {
 
 export class OptionalValidator<Out, In> extends Validator<null | undefined | Out, null | undefined | In> {
   constructor(private readonly validator: Validator<Out, In>) {
-    super();
+    super(true);
     Object.freeze(this);
   }
 
@@ -1456,7 +1458,7 @@ export class OptionalValidator<Out, In> extends Validator<null | undefined | Out
 
 export class OptionalUndefinedValidator<Out, In> extends Validator<undefined | Out, undefined | In> {
   constructor(private readonly validator: Validator<Out, In>) {
-    super();
+    super(true);
     Object.freeze(this);
   }
 
@@ -1547,6 +1549,10 @@ export function isPromise(value: any): value is PromiseLike<any> {
 }
 
 export class IgnoreValidator extends Validator<undefined> {
+  constructor() {
+    super(true);
+    Object.freeze(this);
+  }
   validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined>, failure: FailureCallback): void {
     return success(undefined);
   }

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -885,8 +885,10 @@ export class SetValidator<T = unknown, E extends boolean = true> extends Validat
     const items: T[] = [];
     let violations: Violation[] = [];
     let expectedResponses = (value instanceof Set ? value.size : value.length);
+    let done = false;
 
     const reportResult = () => {
+      done = true;
       if (violations.length > 0) {
         failure(violations);
       } else {
@@ -912,10 +914,18 @@ export class SetValidator<T = unknown, E extends boolean = true> extends Validat
     let i = 0;
     for (const entry of value) {
       const index = i++
-      this.values.validatePathV2(entry, path.index(index), ctx,
-        (result) => reportItem(index, result, undefined),
-        (error) => reportItem(index, undefined, error)
-      );
+      try {
+        this.values.validatePathV2(entry, path.index(index), ctx,
+          (result) => reportItem(index, result, undefined),
+          (error) => reportItem(index, undefined, error)
+        );
+      } catch (error) {
+        if (done) {
+          // Already reported: the throw came from downstream, not from this item.
+          throw error;
+        }
+        reportItem(index, undefined, error);
+      }
     }
   }
 }

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -589,7 +589,7 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     let violations: Violation[] = [];
-    let conversionViolation: Violation | undefined;
+    const conflictingConversions: Set<any> = new Set();
     let foundMatch = false;
     let convertedValue: any;
     let expectedResponses = this.validators.length;
@@ -601,11 +601,12 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
         convertedValue = result;
         foundMatch = true;
       } else if (!deepEqual(result, convertedValue)) {
-        conversionViolation = new Violation(path, 'ConflictingConversions', value);
+        conflictingConversions.add(convertedValue);
+        conflictingConversions.add(result);
       }
       if (--expectedResponses === 0) {
-        if (conversionViolation) {
-          failure([conversionViolation]);
+        if (conflictingConversions.size > 0) {
+          failure([new Violation(path, 'ConflictingConversions', Array.from(conflictingConversions))]);
         } else if (foundMatch) {
           success(convertedValue);
         } else {
@@ -1419,6 +1420,7 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
     let violations: Violation[] = [];
     let firstResult = true;
     let convertedValue: any;
+    const conflictingConversion = new Set<any>();
     let expectedResponses = this.validators.length;
 
     const reportResult = (result: undefined | Out, error: any) => {
@@ -1428,9 +1430,13 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
         convertedValue = result;
         firstResult = false;
       } else if (!deepEqual(result, convertedValue)) {
-        violations.push(new Violation(path, 'ConflictingConversions', value));
+        conflictingConversion.add(convertedValue);
+        conflictingConversion.add(result);
       }
       if (--expectedResponses === 0) {
+        if (conflictingConversion.size > 0) {
+          violations.push(new Violation(path, 'ConflictingConversions', Array.from(conflictingConversion)));
+        }
         if (violations.length > 0) {
           failure(violations);
         } else {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -601,7 +601,7 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
         convertedValue = result;
         foundMatch = true;
       } else if (!deepEqual(result, convertedValue)) {
-        conversionViolation = new Violation(path, 'ConflictingConversions', result);
+        conversionViolation = new Violation(path, 'ConflictingConversions', value);
       }
       if (--expectedResponses === 0) {
         if (conversionViolation) {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -1373,10 +1373,10 @@ export class AssertTrueValidator<In> extends Validator<In, In> {
       if (!this.fn(value, path, ctx)) {
         return failure(new Violation(this.path ? this.path.connectTo(path) : path, this.type));
       }
-      return success(value);
     } catch (error) {
       return failure(violationsOf(error, this.path ? this.path.connectTo(path) : path));
     }
+    return success(value);
   }
 }
 

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -138,7 +138,7 @@ export abstract class Validator<Out = unknown, In = unknown> {
     );
   }
 
-  allowsUndefined(): boolean {
+  skipUndefined(): boolean {
     return false;
   }
 
@@ -481,19 +481,19 @@ export class CheckValidator<In> extends Validator<In, In> {
 }
 
 export abstract class CompositeValidator<Out = unknown, In = unknown> extends Validator<Out, In> {
-  constructor(private readonly _allowsUndefined: boolean) {
+  constructor(private readonly _skipUndefined: boolean) {
     super();
   }
 
-  allowsUndefined(): boolean {
-    return this._allowsUndefined;
+  skipUndefined(): boolean {
+    return this._skipUndefined;
   }
 }
 
 export class CompositionValidator<Out = unknown, In = any> extends CompositeValidator<Out, In> {
   public readonly validators: Validator[];
   constructor(validators: Validator[]) {
-    super(validators.every((v) => v.allowsUndefined()));
+    super(validators.every((v) => v.skipUndefined()));
     this.validators = ([] as Validator[]).concat(validators);
     Object.freeze(this.validators);
     Object.freeze(this);
@@ -514,9 +514,10 @@ export class CompositionValidator<Out = unknown, In = any> extends CompositeVali
   }
 }
 
-export class OneOfValidator<Out = unknown> extends CompositeValidator<Out> {
+export class OneOfValidator<Out = unknown> extends Validator<Out> {
   constructor(public readonly validators: [Validator<Out>, ...Validator<Out>[]]) {
-    super(validators.filter((v) => v.allowsUndefined()).length === 1);
+    super();
+    // NOTE: This doesn't skipUndefined because a child validator may allow undefined even if it's not configured to skipUndefined
     Object.freeze(this.validators);
     Object.freeze(this);
   }
@@ -1338,9 +1339,18 @@ export class HasValueValidator<InOut> extends Validator<InOut> {
   }
 }
 
+/**
+ * Runs input through all validators requiring all succeed. Returns the first 
+ * successful result. If multiple validators succeed, they must return deepEqual value.
+ * Consider wrapping child validators with `V.check()` to ensure that the there are no
+ * conflicting conversions.
+ */
 export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
   constructor(public readonly validators: [Validator<Out, In>, ...Validator<Out, In>[]]) {
-    super(validators.every(v => v.allowsUndefined()));
+    super(validators.every(v => v.skipUndefined()));
+    if (validators.length === 0) {
+      throw new Error('At least one validator required');
+    }
     Object.freeze(this.validators);
     Object.freeze(this);
   }
@@ -1371,13 +1381,17 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
 
     for (let i = 0; i < this.validators.length; i++) {
       const validator = this.validators[i];
-      validator.validatePathV2(
-        value,
-        path,
-        ctx,
-        (result) => reportResult(result, undefined),
-        (error) => reportResult(undefined, error)
-      );
+      try {
+        validator.validatePathV2(
+          value,
+          path,
+          ctx,
+          (result) => reportResult(result, undefined),
+          (error) => reportResult(undefined, error)
+        );
+      } catch (error) {
+        reportResult(undefined, error);
+      }
     }
   }
 }
@@ -1460,7 +1474,7 @@ export class OptionalValidator<Out, In> extends Validator<null | undefined | Out
     Object.freeze(this);
   }
 
-  allowsUndefined(): boolean {
+  skipUndefined(): boolean {
     return true;
   }
 
@@ -1479,7 +1493,7 @@ export class OptionalUndefinedValidator<Out, In> extends Validator<undefined | O
     Object.freeze(this);
   }
 
-  allowsUndefined(): boolean {
+  skipUndefined(): boolean {
     return true;
   }
 
@@ -1570,7 +1584,7 @@ export function isPromise(value: any): value is PromiseLike<any> {
 }
 
 export class IgnoreValidator extends Validator<undefined> {
-  allowsUndefined(): boolean {
+  skipUndefined(): boolean {
     return true;
   }
   validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined>, failure: FailureCallback): void {

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -62,8 +62,6 @@ export interface FailureCallback {
 }
 
 export abstract class Validator<Out = unknown, In = unknown> {
-  constructor(public readonly allowsUndefined: boolean = false) {}
-
   validateGroup(value: In, group: Group): Promise<ValidationResult<Out>> {
     return this.validate(value, { group });
   }
@@ -138,6 +136,10 @@ export abstract class Validator<Out = unknown, In = unknown> {
         failure(violationsOf(error, path));
       }
     );
+  }
+
+  allowsUndefined(): boolean {
+    return false;
   }
 
   next<NextOut = unknown, T1 = unknown, T2 = unknown, T3 = unknown, T4 = unknown>(...validators: NextCompositionParameters<NextOut, Out, T1, T2, T3, T4>) {
@@ -478,10 +480,20 @@ export class CheckValidator<In> extends Validator<In, In> {
   }
 }
 
-export class CompositionValidator<Out = unknown, In = any> extends Validator<Out, In> {
+export abstract class CompositeValidator<Out = unknown, In = unknown> extends Validator<Out, In> {
+  constructor(private readonly _allowsUndefined: boolean) {
+    super();
+  }
+
+  allowsUndefined(): boolean {
+    return this._allowsUndefined;
+  }
+}
+
+export class CompositionValidator<Out = unknown, In = any> extends CompositeValidator<Out, In> {
   public readonly validators: Validator[];
   constructor(validators: Validator[]) {
-    super();
+    super(validators.every((v) => v.allowsUndefined()));
     this.validators = ([] as Validator[]).concat(validators);
     Object.freeze(this.validators);
     Object.freeze(this);
@@ -502,9 +514,9 @@ export class CompositionValidator<Out = unknown, In = any> extends Validator<Out
   }
 }
 
-export class OneOfValidator<Out = unknown> extends Validator<Out> {
+export class OneOfValidator<Out = unknown> extends CompositeValidator<Out> {
   constructor(public readonly validators: [Validator<Out>, ...Validator<Out>[]]) {
-    super();
+    super(validators.filter((v) => v.allowsUndefined()).length === 1);
     Object.freeze(this.validators);
     Object.freeze(this);
   }
@@ -538,12 +550,13 @@ export class OneOfValidator<Out = unknown> extends Validator<Out> {
   }
 }
 
-export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, In> {
+export class AnyOfValidator<Out = unknown, In = unknown> extends CompositeValidator<Out, In> {
   constructor(public readonly validators: Validator<Out>[]) {
-    super();
+    super(validators.some((v) => v.allowsUndefined()));
     Object.freeze(this.validators);
     Object.freeze(this);
   }
+
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     let violations: Violation[] = [];
     const validateNext = (index: number) => {
@@ -1325,9 +1338,9 @@ export class HasValueValidator<InOut> extends Validator<InOut> {
   }
 }
 
-export class AllOfValidator<Out, In> extends Validator<Out, In> {
+export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
   constructor(public readonly validators: [Validator<Out, In>, ...Validator<Out, In>[]]) {
-    super();
+    super(validators.every(v => v.allowsUndefined()));
     Object.freeze(this.validators);
     Object.freeze(this);
   }
@@ -1443,8 +1456,12 @@ export class PatternNormalizer extends PatternValidator {
 
 export class OptionalValidator<Out, In> extends Validator<null | undefined | Out, null | undefined | In> {
   constructor(private readonly validator: Validator<Out, In>) {
-    super(true);
+    super();
     Object.freeze(this);
+  }
+
+  allowsUndefined(): boolean {
+    return true;
   }
 
   validatePathV2(value: null | undefined | In, path: Path, ctx: ValidationContext, success: SuccessCallback<null | undefined | Out>, failure: FailureCallback): void {
@@ -1458,8 +1475,12 @@ export class OptionalValidator<Out, In> extends Validator<null | undefined | Out
 
 export class OptionalUndefinedValidator<Out, In> extends Validator<undefined | Out, undefined | In> {
   constructor(private readonly validator: Validator<Out, In>) {
-    super(true);
+    super();
     Object.freeze(this);
+  }
+
+  allowsUndefined(): boolean {
+    return true;
   }
 
   validatePathV2(value: undefined | In, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined | Out>, failure: FailureCallback): void {
@@ -1549,9 +1570,8 @@ export function isPromise(value: any): value is PromiseLike<any> {
 }
 
 export class IgnoreValidator extends Validator<undefined> {
-  constructor() {
-    super(true);
-    Object.freeze(this);
+  allowsUndefined(): boolean {
+    return true;
   }
   validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<undefined>, failure: FailureCallback): void {
     return success(undefined);

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -551,29 +551,63 @@ export class OneOfValidator<Out = unknown> extends Validator<Out> {
   }
 }
 
-export class AnyOfValidator<Out = unknown, In = unknown> extends CompositeValidator<Out, In> {
+/**
+ * Runs input through all validators requiring that one or more succeed. Returns the first 
+ * successful result. If multiple validators succeed, they must return deepEqual value.
+ * Consider wrapping child validators with `V.check()` to ensure that there are no
+ * conflicting conversions.
+ */
+export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, In> {
   constructor(public readonly validators: Validator<Out>[]) {
-    super(validators.some((v) => v.allowsUndefined()));
+    super();
+    if (this.validators.length === 0) {
+      throw new Error('At least one validator required');
+    }
+    // NOTE: This doesn't extend CompositeValidator because even if some of the validators would allow undefined,
+    // others may convert the value, e.g. V.anyOf(V.nullTo('default'), V.optionalStrict(V.string()))
     Object.freeze(this.validators);
     Object.freeze(this);
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
     let violations: Violation[] = [];
-    const validateNext = (index: number) => {
-      if (index < this.validators.length) {
-        this.validators[index].validatePathV2(value, path, ctx,
-          success,
-          (error) => {
-            violations = violations.concat(violationsOf(error, path));
-            validateNext(index + 1);
-          }
-        );
-      } else {
-        failure(violations);
+    let conversionViolation: Violation | undefined;
+    let foundMatch = false;
+    let convertedValue: any;
+    let expectedResponses = this.validators.length;
+
+    const reportResult = (result: undefined | Out, error: any) => {
+      if (error) {
+        violations = violations.concat(violationsOf(error, path));
+      } else if (!foundMatch) {
+        convertedValue = result;
+        foundMatch = true;
+      } else if (!deepEqual(result, convertedValue)) {
+        conversionViolation = new Violation(path, 'ConflictingConversions', result);
+      }
+      if (--expectedResponses === 0) {
+        if (conversionViolation) {
+          failure([conversionViolation]);
+        } else if (foundMatch) {
+          success(convertedValue);
+        } else {
+          failure(violations);
+        }
       }
     }
-    validateNext(0);
+    for (const validator of this.validators) {
+      try {
+        validator.validatePathV2(
+          value,
+          path,
+          ctx,
+          (result) => reportResult(result, undefined),
+          (error) => reportResult(undefined, error)
+        );
+      } catch (error) {
+        reportResult(undefined, error);
+      }
+    }
   }
 }
 

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -379,8 +379,10 @@ export class ValidatorFnWrapper<Out = unknown, In = unknown> extends Validator<O
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    let done = false;
     try {
       const maybePromise = this.fn(value, path, ctx);
+      done = true;
       if (isPromise(maybePromise)) {
         maybePromise.then(
           success,
@@ -390,6 +392,10 @@ export class ValidatorFnWrapper<Out = unknown, In = unknown> extends Validator<O
         success(maybePromise);
       }
     } catch (error) {
+      if (done) {
+        // Already handed off: the throw came from downstream, not from the validator function.
+        throw error;
+      }
       ctx.failureV2(violationsOf(error, path), value, success, failure);
     }
   }
@@ -402,11 +408,22 @@ export class ValidatorFnWrapperV2<Out = unknown, In = unknown> extends Validator
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    let done = false;
     try {
       this.fn(value, path, ctx,
-        success,
-        error => ctx.failureV2(error, value, success, failure));
+        (result) => {
+          done = true;
+          success(result);
+        },
+        error => {
+          done = true;
+          ctx.failureV2(error, value, success, failure);
+        });
     } catch (error) {
+      if (done) {
+        // Already reported: the throw came from downstream, not from the validator function.
+        throw error;
+      }
       ctx.failureV2(violationsOf(error, path), value, success, failure);
     }
   }
@@ -1626,7 +1643,10 @@ export class ValueMapper<Out = unknown, In = unknown> extends Validator<Out, In>
   }
 
   validatePathV2(value: In, path: Path, ctx: ValidationContext, success: SuccessCallback<Out>, failure: FailureCallback): void {
+    let done = false;
+
     const handleResult = (result: any) => {
+      done = true;
       if (result instanceof Violation) {
         ctx.failureV2(result, value, success, failure);
       } else {
@@ -1645,6 +1665,10 @@ export class ValueMapper<Out = unknown, In = unknown> extends Validator<Out, In>
         handleResult(maybePromise);
       }
     } catch (error) {
+      if (done) {
+        // Already reported: the throw came from downstream, not from the mapping function.
+        throw error;
+      }
       failure(violationsOf(error, path));
     }
   }

--- a/packages/core/src/validators.ts
+++ b/packages/core/src/validators.ts
@@ -138,6 +138,15 @@ export abstract class Validator<Out = unknown, In = unknown> {
     );
   }
 
+  /**
+   * Indicates whether this validator allows undefined values to be skipped. If true, the validator 
+   * will not be called for undefined values and the value will be considered valid. If false, the 
+   * validator will be called for undefined values and may return a violation.
+   * 
+   * NOTE: Return `true` only if `undefined` input is allowed AND results in undefined output.
+   * 
+   * @returns true if undefined values are allowed and will be skipped, false otherwise.
+   */
   skipUndefined(): boolean {
     return false;
   }
@@ -422,9 +431,11 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
     }
     let expectedResponses = value.length;
     let violations: Violation[] = [];
+    let done = false;
 
     const reportResult = () => {
       if (--expectedResponses === 0) {
+        done = true;
         if (violations.length > 0) {
           failure(violations);
         } else {
@@ -447,6 +458,10 @@ export class ArrayValidator<Out = unknown> extends Validator<Out[]> {
             reportResult();
           });
       } catch (error) {
+        if (done) {
+          // Already reported: the throw came from downstream, not from this item.
+          throw error;
+        }
         violations = violations.concat(violationsOf(error, itemPath));
         reportResult();
       }
@@ -563,8 +578,6 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
     if (this.validators.length === 0) {
       throw new Error('At least one validator required');
     }
-    // NOTE: This doesn't extend CompositeValidator because even if some of the validators would allow undefined,
-    // others may convert the value, e.g. V.anyOf(V.nullTo('default'), V.optionalStrict(V.string()))
     Object.freeze(this.validators);
     Object.freeze(this);
   }
@@ -575,6 +588,7 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
     let foundMatch = false;
     let convertedValue: any;
     let expectedResponses = this.validators.length;
+    let done = false;
 
     const reportResult = (result: undefined | Out, error: any) => {
       if (error) {
@@ -586,6 +600,7 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
         conversionViolation = new Violation(path, 'ConflictingConversions', result);
       }
       if (--expectedResponses === 0) {
+        done = true;
         if (conversionViolation) {
           failure([conversionViolation]);
         } else if (foundMatch) {
@@ -605,6 +620,10 @@ export class AnyOfValidator<Out = unknown, In = unknown> extends Validator<Out, 
           (error) => reportResult(undefined, error)
         );
       } catch (error) {
+        if (done) {
+          // Already reported: the throw came from downstream, not from this validator.
+          throw error;
+        }
         reportResult(undefined, error);
       }
     }
@@ -752,8 +771,10 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
     let violations: Violation[] = [];
     const entries: [K, V][] = [];
     let expectedResponses = map.size * 2;
+    let done = false;
 
     const reportResult = () => {
+      done = true;
       if (violations.length > 0) {
         failure(violations);
       } else {
@@ -787,6 +808,8 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
           (error) => reportEntry(entryIndex, 0, undefined, error)
         );
       } catch (error) {
+        // No `done` check needed: within an entry the key is always reported before the
+        // value, so the last response is always a value and `done` cannot be set here.
         reportEntry(entryIndex, 0, undefined, error);
       }
       try {
@@ -795,6 +818,10 @@ export class MapValidator<K = unknown, V = unknown, E extends boolean = true> ex
           (error) => reportEntry(entryIndex, 1, undefined, error)
         );
       } catch (error) {
+        if (done) {
+          // Already reported: the throw came from downstream, not from this value.
+          throw error;
+        }
         reportEntry(entryIndex, 1, undefined, error);
       }
     }
@@ -1332,10 +1359,14 @@ export class AssertTrueValidator<In> extends Validator<In, In> {
   }
 
   validatePathV2(value: any, path: Path, ctx: ValidationContext, success: SuccessCallback<In>, failure: FailureCallback): void {
-    if (!this.fn(value, path, ctx)) {
-      return failure(new Violation(this.path ? this.path.connectTo(path) : path, this.type));
+    try {
+      if (!this.fn(value, path, ctx)) {
+        return failure(new Violation(this.path ? this.path.connectTo(path) : path, this.type));
+      }
+      return success(value);
+    } catch (error) {
+      return failure(violationsOf(error, this.path ? this.path.connectTo(path) : path));
     }
-    return success(value);
   }
 }
 
@@ -1394,6 +1425,7 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
     let firstResult = true;
     let convertedValue: any;
     let expectedResponses = this.validators.length;
+    let done = false;
 
     const reportResult = (result: undefined | Out, error: any) => {
       if (error) {
@@ -1405,6 +1437,7 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
         violations.push(new Violation(path, 'ConflictingConversions', value));
       }
       if (--expectedResponses === 0) {
+        done = true;
         if (violations.length > 0) {
           failure(violations);
         } else {
@@ -1424,6 +1457,10 @@ export class AllOfValidator<Out, In> extends CompositeValidator<Out, In> {
           (error) => reportResult(undefined, error)
         );
       } catch (error) {
+        if (done) {
+          // Already reported: the throw came from downstream, not from this validator.
+          throw error;
+        }
         reportResult(undefined, error);
       }
     }

--- a/packages/core/src/warnLogger.spec.ts
+++ b/packages/core/src/warnLogger.spec.ts
@@ -1,0 +1,175 @@
+import { describe, test, expect } from 'vitest';
+import { Path } from '@finnair/path';
+import { V } from './V.js';
+import { EnumMismatch, Violation, ValidatorType, WarnLogger, defaultViolations } from './validators.js';
+import { anyIndexPath, dedupWarnLogger, warnLoggerKey } from './warnLogger.js';
+
+const ROOT = Path.ROOT;
+
+enum SourceEnum {
+  KNOWN = 'KNOWN',
+}
+
+/** Object type that ignores an unknown property and an unknown enum value. */
+const sourceType = () => V.object({ properties: { known: V.string(), status: V.enum(SourceEnum, 'SourceEnum') } });
+
+const collect = () => {
+  const violations: Violation[] = [];
+  const logger: WarnLogger = violation => violations.push(violation);
+  return { violations, logger, keys: () => violations.map(warnLoggerKey) };
+};
+
+describe('anyIndexPath', () => {
+  test('root', () => expect(anyIndexPath(ROOT)).toEqual('$'));
+
+  test('property', () => expect(anyIndexPath(Path.of('newProperty'))).toEqual('$.newProperty'));
+
+  test('array index is replaced by *', () => expect(anyIndexPath(Path.of('items', 3, 'newProperty'))).toEqual('$.items[*].newProperty'));
+
+  test('every index is replaced', () => expect(anyIndexPath(Path.of(0, 1, 2))).toEqual('$[*][*][*]'));
+
+  test('different indices normalize to the same path', () =>
+    expect(anyIndexPath(Path.of('items', 0, 'p'))).toEqual(anyIndexPath(Path.of('items', 999, 'p'))));
+
+  test('non-identifier property names are quoted like Path.toJSON', () =>
+    expect(anyIndexPath(Path.of('with space'))).toEqual(Path.of('with space').toJSON()));
+});
+
+describe('warnLoggerKey', () => {
+  test('same property in different array elements has the same key', () =>
+    expect(warnLoggerKey(defaultViolations.unknownProperty(Path.of('items', 0, 'added')))).toEqual(
+      warnLoggerKey(defaultViolations.unknownProperty(Path.of('items', 7, 'added'))),
+    ));
+
+  test('different properties have different keys', () =>
+    expect(warnLoggerKey(defaultViolations.unknownProperty(Path.of('a')))).not.toEqual(
+      warnLoggerKey(defaultViolations.unknownProperty(Path.of('b'))),
+    ));
+
+  test('different violation types have different keys', () =>
+    expect(warnLoggerKey(defaultViolations.unknownProperty(Path.of('a')))).not.toEqual(
+      warnLoggerKey(new Violation(Path.of('a'), ValidatorType.UnknownPropertyDenied)),
+    ));
+
+  test('each unknown enum value is a distinct finding', () =>
+    expect(warnLoggerKey(new EnumMismatch(Path.of('status'), 'SourceEnum', 'NEW_A'))).not.toEqual(
+      warnLoggerKey(new EnumMismatch(Path.of('status'), 'SourceEnum', 'NEW_B')),
+    ));
+
+  test('same unknown enum value in different elements has the same key', () =>
+    expect(warnLoggerKey(new EnumMismatch(Path.of('items', 0, 'status'), 'SourceEnum', 'NEW'))).toEqual(
+      warnLoggerKey(new EnumMismatch(Path.of('items', 5, 'status'), 'SourceEnum', 'NEW')),
+    ));
+});
+
+describe('dedupWarnLogger', () => {
+  test('reports an unknown property once per array, not once per element', async () => {
+    const { violations, logger } = collect();
+    const warnLogger = dedupWarnLogger(logger);
+    const validator = V.array(sourceType());
+    const input = [0, 1, 2].map(() => ({ known: 'value', status: 'KNOWN', added: 'value' }));
+
+    const result = await validator.validate(input, { ignoreUnknownProperties: true, warnLogger });
+
+    expect(result.isSuccess()).toBe(true);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].type).toEqual(ValidatorType.UnknownProperty);
+  });
+
+  test('deduplicates across separate validations', async () => {
+    const { violations, logger } = collect();
+    const warnLogger = dedupWarnLogger(logger);
+    const validator = sourceType();
+    const input = { known: 'value', status: 'KNOWN', added: 'value' };
+
+    for (let i = 0; i < 100; i++) {
+      expect((await validator.validate(input, { ignoreUnknownProperties: true, warnLogger })).isSuccess()).toBe(true);
+    }
+
+    expect(violations).toHaveLength(1);
+  });
+
+  test('deduplicates repeated branches of anyOf', async () => {
+    const { violations, logger } = collect();
+    const warnLogger = dedupWarnLogger(logger);
+    const validator = V.anyOf(sourceType(), sourceType(), sourceType());
+
+    const result = await validator.validate({ known: 'value', status: 'KNOWN', added: 'value' }, { ignoreUnknownProperties: true, warnLogger });
+
+    expect(result.isSuccess()).toBe(true);
+    expect(violations).toHaveLength(1);
+  });
+
+  test('distinct findings are all reported', async () => {
+    const { violations, logger, keys } = collect();
+    const warnLogger = dedupWarnLogger(logger);
+    const validator = V.array(sourceType());
+    const input = [
+      { known: 'value', status: 'NEW_STATUS', addedA: 'value' },
+      { known: 'value', status: 'ANOTHER_STATUS', addedB: 'value' },
+    ];
+
+    const result = await validator.validate(input, {
+      ignoreUnknownProperties: true,
+      ignoreUnknownEnumValues: true,
+      warnLogger,
+    });
+
+    expect(result.isSuccess()).toBe(true);
+    expect(keys().sort()).toEqual([
+      'EnumMismatch $[*].status ANOTHER_STATUS',
+      'EnumMismatch $[*].status NEW_STATUS',
+      'UnknownProperty $[*].addedA undefined',
+      'UnknownProperty $[*].addedB undefined',
+    ]);
+  });
+
+  test('a new finding appearing later is still reported', async () => {
+    const { violations, logger } = collect();
+    const warnLogger = dedupWarnLogger(logger);
+    const validator = sourceType();
+    const options = { ignoreUnknownProperties: true, warnLogger };
+
+    await validator.validate({ known: 'value', status: 'KNOWN', first: 'value' }, options);
+    await validator.validate({ known: 'value', status: 'KNOWN', first: 'value' }, options);
+    expect(violations).toHaveLength(1);
+
+    await validator.validate({ known: 'value', status: 'KNOWN', second: 'value' }, options);
+    expect(violations).toHaveLength(2);
+  });
+
+  test('separate instances have separate state', async () => {
+    const first = collect();
+    const second = collect();
+    const validator = sourceType();
+    const input = { known: 'value', status: 'KNOWN', added: 'value' };
+
+    await validator.validate(input, { ignoreUnknownProperties: true, warnLogger: dedupWarnLogger(first.logger) });
+    await validator.validate(input, { ignoreUnknownProperties: true, warnLogger: dedupWarnLogger(second.logger) });
+
+    expect(first.violations).toHaveLength(1);
+    expect(second.violations).toHaveLength(1);
+  });
+
+  test('forwards the ValidatorOptions of the reported violation', async () => {
+    const seen: any[] = [];
+    const warnLogger = dedupWarnLogger((violation, options) => seen.push(options));
+    const options = { ignoreUnknownProperties: true, warnLogger };
+
+    await sourceType().validate({ known: 'value', status: 'KNOWN', added: 'value' }, options);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].ignoreUnknownProperties).toBe(true);
+  });
+
+  test('custom keyOf overrides the identity', async () => {
+    const { violations, logger } = collect();
+    // Everything is the same finding.
+    const warnLogger = dedupWarnLogger(logger, () => 'constant');
+    const validator = sourceType();
+
+    await validator.validate({ known: 'value', status: 'KNOWN', a: 1, b: 2 }, { ignoreUnknownProperties: true, warnLogger });
+
+    expect(violations).toHaveLength(1);
+  });
+});

--- a/packages/core/src/warnLogger.ts
+++ b/packages/core/src/warnLogger.ts
@@ -1,0 +1,69 @@
+import { Path } from '@finnair/path';
+import { Violation, WarnLogger } from './validators.js';
+
+/**
+ * Returns `path` as a string with all array indices replaced by `*`, e.g.
+ * `$.items[3].newProperty` becomes `$.items[*].newProperty`.
+ *
+ * Elements of an array share the same schema, so an ignored violation reported for one element is
+ * the same finding as the one reported for every other element of that array.
+ */
+export function anyIndexPath(path: Path): string {
+  let normalized = '$';
+  for (const component of path) {
+    normalized += typeof component === 'number' ? '[*]' : Path.componentToString(component);
+  }
+  return normalized;
+}
+
+/**
+ * Default identity of an ignored `Violation`: what kind of finding it is and where in the schema
+ * it is, with array indices normalized by `anyIndexPath`.
+ *
+ * `invalidValue` is part of the identity because each unknown enum value is a separate finding
+ * (`EnumMismatch`). It is always `undefined` for `UnknownProperty`, where the path alone identifies
+ * the new property.
+ */
+export function warnLoggerKey(violation: Violation): string {
+  return `${violation.type} ${anyIndexPath(violation.path)} ${String(violation.invalidValue)}`;
+}
+
+/**
+ * Wraps `logger` so that each distinct ignored violation is reported only once for the lifetime of
+ * the returned function.
+ *
+ * `warnLogger` exists to tell you about backwards compatible changes in source data - a source
+ * system that started sending a new property or a new enum value. That is a small, fixed set of
+ * findings, but the same validator keeps meeting the same changed data on every request until the
+ * validator is updated, so an undeduplicated logger reports the same finding indefinitely.
+ *
+ * Create it **once** and reuse it, so that deduplication spans validations:
+ *
+ * ```typescript
+ * const warnLogger = dedupWarnLogger(violation => console.warn('Source data changed:', violation));
+ *
+ * // per request
+ * await validator.validate(input, { ignoreUnknownProperties: true, warnLogger });
+ * ```
+ *
+ * Creating it per validation only deduplicates within that single run, which is rarely the
+ * interesting part.
+ *
+ * The set of reported keys is retained for the lifetime of the returned function. It is bounded by
+ * the schema (violation type x normalized path x enum value), not by the amount of data validated.
+ * Pass `keyOf` to use a different identity - for example if a custom `ValidationContext` ignores
+ * violation types whose `invalidValue` is unbounded.
+ *
+ * @param logger the logger to forward first occurrences to
+ * @param keyOf identity of a violation, `warnLoggerKey` by default
+ */
+export function dedupWarnLogger(logger: WarnLogger, keyOf: (violation: Violation) => string = warnLoggerKey): WarnLogger {
+  const reported = new Set<string>();
+  return (violation, options) => {
+    const key = keyOf(violation);
+    if (!reported.has(key)) {
+      reported.add(key);
+      logger(violation, options);
+    }
+  };
+}

--- a/packages/diff/src/Diff.ts
+++ b/packages/diff/src/Diff.ts
@@ -1,5 +1,5 @@
 import { Node } from '@finnair/path';
-import { arrayOrPlainObject, Change, DiffNode, DiffNodeConfig } from './DiffNode';
+import { arrayOrPlainObject, Change, DiffNode, DiffNodeConfig } from './DiffNode.js';
 
 export interface DiffConfig extends DiffNodeConfig {
   readonly includeObjects?: boolean;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
     coverage: {
       enabled: true,
       include: ['**/*.ts'],
-      exclude: ['**/*.d.ts', '**/*.spec.ts', '**/*.test.ts', 'vitest.config.ts'],
+      // Library code all lives under packages/*/src, so root-level *.ts is tooling or a local
+      // scratch file (e.g. a benchmark validator) and must not count against coverage.
+      exclude: ['**/*.d.ts', '**/*.spec.ts', '**/*.test.ts', '*.ts'],
       provider: 'v8',
       reporter: [['lcov'], ['text'], ['text-summary']],
       reportsDirectory: './coverage',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,38 +11,38 @@
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@babel/code-frame@^7.0.0":
-  version "7.26.2"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
-  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.29.7"
     js-tokens "^4.0.0"
-    picocolors "^1.0.0"
+    picocolors "^1.1.1"
 
-"@babel/helper-string-parser@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
-  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
 
-"@babel/helper-validator-identifier@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
-  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/parser@^7.25.4":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.3.tgz#8c51c5db6ddf08134af1ddbacf16aaab48bac234"
-  integrity sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
   dependencies:
-    "@babel/types" "^7.26.3"
+    "@babel/types" "^7.29.8"
 
-"@babel/types@^7.25.4", "@babel/types@^7.26.3":
-  version "7.26.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.3.tgz#37e79830f04c2b5687acc77db97fbc75fb81f3c0"
-  integrity sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==
+"@babel/types@^7.25.4", "@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
   dependencies:
-    "@babel/helper-string-parser" "^7.25.9"
-    "@babel/helper-validator-identifier" "^7.25.9"
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@bcoe/v8-coverage@^1.0.2":
   version "1.0.2"
@@ -57,161 +57,169 @@
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@emnapi/core@^1.1.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.5.0.tgz#85cd84537ec989cebb2343606a1ee663ce4edaf0"
-  integrity sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.3.tgz#5e95348a42cd1e06f0b9aa380cd74091daa4d520"
+  integrity sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==
   dependencies:
-    "@emnapi/wasi-threads" "1.1.0"
+    "@emnapi/wasi-threads" "1.2.3"
     tslib "^2.4.0"
 
 "@emnapi/runtime@^1.1.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.5.0.tgz#9aebfcb9b17195dce3ab53c86787a6b7d058db73"
-  integrity sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.3.tgz#84257ae3b0531eb2aec1ffa23d70700da007ba95"
+  integrity sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/wasi-threads@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz#60b2102fddc9ccb78607e4a3cf8403ea69be41bf"
-  integrity sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==
+"@emnapi/wasi-threads@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz#c9bf72fd4be5b928aee894820e8d814ed73916e9"
+  integrity sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==
   dependencies:
     tslib "^2.4.0"
 
-"@esbuild/aix-ppc64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz#bef96351f16520055c947aba28802eede3c9e9a9"
-  integrity sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==
+"@esbuild/aix-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz#bf6e10303bcf2e7c686975fa52f937ec2728d8bc"
+  integrity sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==
 
-"@esbuild/android-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz#d2e70be7d51a529425422091e0dcb90374c1546c"
-  integrity sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==
+"@esbuild/android-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz#0c6246bc8d2c4d172aac2db3fb1190d72bd65504"
+  integrity sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==
 
-"@esbuild/android-arm@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.9.tgz#d2a753fe2a4c73b79437d0ba1480e2d760097419"
-  integrity sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==
+"@esbuild/android-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.2.tgz#2d84ece6a4e2684d92be26ee13d42757d831c381"
+  integrity sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==
 
-"@esbuild/android-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.9.tgz#5278836e3c7ae75761626962f902a0d55352e683"
-  integrity sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==
+"@esbuild/android-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.2.tgz#fc38d4d6358d8dc1cf53f09f7589fe436eb64801"
+  integrity sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==
 
-"@esbuild/darwin-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz#f1513eaf9ec8fa15dcaf4c341b0f005d3e8b47ae"
-  integrity sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==
+"@esbuild/darwin-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz#f83afeeac1d7dac01c7a2fd012b3e451a0591fcc"
+  integrity sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==
 
-"@esbuild/darwin-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz#e27dbc3b507b3a1cea3b9280a04b8b6b725f82be"
-  integrity sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==
+"@esbuild/darwin-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz#510147c055a795588dbbe14fd6b1b8ad0a2f30de"
+  integrity sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==
 
-"@esbuild/freebsd-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz#364e3e5b7a1fd45d92be08c6cc5d890ca75908ca"
-  integrity sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==
+"@esbuild/freebsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz#093b9200ecf0b115ba4e5e248a7485c9c5f8bd5e"
+  integrity sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==
 
-"@esbuild/freebsd-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz#7c869b45faeb3df668e19ace07335a0711ec56ab"
-  integrity sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==
+"@esbuild/freebsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz#0be22b6df925d213e841ea87123af5df80b0faf7"
+  integrity sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==
 
-"@esbuild/linux-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz#48d42861758c940b61abea43ba9a29b186d6cb8b"
-  integrity sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==
+"@esbuild/linux-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz#1bdbc651cda9ba9995c53ed9c71ceaa65094762d"
+  integrity sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==
 
-"@esbuild/linux-arm@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz#6ce4b9cabf148274101701d112b89dc67cc52f37"
-  integrity sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==
+"@esbuild/linux-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz#beb12ad72b84f72d28488cc1b8ee9f7eb141d753"
+  integrity sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==
 
-"@esbuild/linux-ia32@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz#207e54899b79cac9c26c323fc1caa32e3143f1c4"
-  integrity sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==
+"@esbuild/linux-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz#b81f9d55529b45c206a46a138214b1aa6879696b"
+  integrity sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==
 
-"@esbuild/linux-loong64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz#0ba48a127159a8f6abb5827f21198b999ffd1fc0"
-  integrity sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==
+"@esbuild/linux-loong64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz#598667241a04c99b76ed6ef940ac50038c419f98"
+  integrity sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==
 
-"@esbuild/linux-mips64el@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz#a4d4cc693d185f66a6afde94f772b38ce5d64eb5"
-  integrity sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==
+"@esbuild/linux-mips64el@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz#1c51eb9cea903f53d97b5af3b1841db70f5596ca"
+  integrity sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==
 
-"@esbuild/linux-ppc64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz#0f5805c1c6d6435a1dafdc043cb07a19050357db"
-  integrity sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==
+"@esbuild/linux-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz#63dd61f17ceb31a81227f413feac8a71bc2c51f2"
+  integrity sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==
 
-"@esbuild/linux-riscv64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz#6776edece0f8fca79f3386398b5183ff2a827547"
-  integrity sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==
+"@esbuild/linux-riscv64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz#3763b08fde5cf25ab1facb8e7752edfe45fbfc27"
+  integrity sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==
 
-"@esbuild/linux-s390x@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz#3f6f29ef036938447c2218d309dc875225861830"
-  integrity sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==
+"@esbuild/linux-s390x@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz#1a137ff293a82906eb3176385bd7e8e0e5cfb7cb"
+  integrity sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==
 
-"@esbuild/linux-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz#831fe0b0e1a80a8b8391224ea2377d5520e1527f"
-  integrity sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==
+"@esbuild/linux-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz#268b36211c146ca54f8fe12c578a8d6ef8979485"
+  integrity sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==
 
-"@esbuild/netbsd-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz#06f99d7eebe035fbbe43de01c9d7e98d2a0aa548"
-  integrity sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==
+"@esbuild/netbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz#22571ad951d62bb6accc82d8d1fad5c8c1ac0ba1"
+  integrity sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==
 
-"@esbuild/netbsd-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz#db99858e6bed6e73911f92a88e4edd3a8c429a52"
-  integrity sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==
+"@esbuild/netbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz#42fcc57297eb0a0ca3f5fc475291f4c1a3f7c0de"
+  integrity sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==
 
-"@esbuild/openbsd-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz#afb886c867e36f9d86bb21e878e1185f5d5a0935"
-  integrity sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==
+"@esbuild/openbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz#9eb32af104ac3dacf4edca01f596664aab0c73ef"
+  integrity sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==
 
-"@esbuild/openbsd-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz#30855c9f8381fac6a0ef5b5f31ac6e7108a66ecf"
-  integrity sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==
+"@esbuild/openbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz#febed2402d6088225e91f20fb4ce2522ad0a4efd"
+  integrity sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==
 
-"@esbuild/openharmony-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz#2f2144af31e67adc2a8e3705c20c2bd97bd88314"
-  integrity sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==
+"@esbuild/openharmony-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz#85641c3d466428bfbccea5f21c26836663fef5ce"
+  integrity sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==
 
-"@esbuild/sunos-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz#69b99a9b5bd226c9eb9c6a73f990fddd497d732e"
-  integrity sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==
+"@esbuild/sunos-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz#a736f9d8962481045fc4c3e54f5479f22c870fb4"
+  integrity sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==
 
-"@esbuild/win32-arm64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz#d789330a712af916c88325f4ffe465f885719c6b"
-  integrity sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==
+"@esbuild/win32-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz#ee5ab40fad186201b652a33f8a5eb149e9e42532"
+  integrity sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==
 
-"@esbuild/win32-ia32@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz#52fc735406bd49688253e74e4e837ac2ba0789e3"
-  integrity sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==
+"@esbuild/win32-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz#c40d28a6d99a127da6711f2afd74b11cb63b06a7"
+  integrity sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==
 
-"@esbuild/win32-x64@0.25.9":
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
-  integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
+"@esbuild/win32-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz#b21affb804cc167c133d95f45b3a1dc1323b9a87"
+  integrity sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==
 
 "@hutson/parse-repository-url@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
+
+"@inquirer/external-editor@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-1.0.3.tgz#c23988291ee676290fdab3fd306e64010a6d13b8"
+  integrity sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.0"
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -231,9 +239,9 @@
   integrity sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==
 
 "@istanbuljs/schema@^0.1.2":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
-  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
 
 "@jest/schemas@^29.6.3":
   version "29.6.3"
@@ -243,12 +251,11 @@
     "@sinclair/typebox" "^0.27.8"
 
 "@jridgewell/gen-mapping@^0.3.5":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
-  integrity sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
   dependencies:
-    "@jridgewell/set-array" "^1.2.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
     "@jridgewell/trace-mapping" "^0.3.24"
 
 "@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
@@ -256,20 +263,10 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/set-array@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
-  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
-
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
-  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
-
-"@jridgewell/sourcemap-codec@^1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
-  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz#f4c663e862f06dc98ca4d453862c46902789a18d"
+  integrity sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -279,18 +276,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.30":
+"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.31":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@jridgewell/trace-mapping@^0.3.24":
-  version "0.3.25"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
-  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -370,6 +359,11 @@
     write-pkg "4.0.0"
     yargs "17.7.2"
     yargs-parser "21.1.1"
+
+"@napi-rs/lzma-linux-x64-gnu@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz#e57d4306966078662038094fb38eb9146dc3aea9"
+  integrity sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==
 
 "@napi-rs/wasm-runtime@0.2.4":
   version "0.2.4"
@@ -551,9 +545,9 @@
     which "^4.0.0"
 
 "@nx/devkit@>=17.1.2 < 21":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/devkit/-/devkit-20.8.2.tgz#4bed032a06ac37910fae5e231849283b8ac415fb"
-  integrity sha512-rr9p2/tZDQivIpuBUpZaFBK6bZ+b5SAjZk75V4tbCUqGW3+5OPuVvBPm+X+7PYwUF6rwSpewxkjWNeGskfCe+Q==
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/devkit/-/devkit-20.8.4.tgz#5b1d132d437e90c30d83865694159e3b304ca77a"
+  integrity sha512-3r+6QmIXXAWL6K7m8vAbW31aniAZmZAZXeMhOhWcJoOAU7ggpCQaM8JP8/kO5ov/Bmhyf0i/SSVXI6kwiR5WNQ==
   dependencies:
     ejs "^3.1.7"
     enquirer "~2.3.6"
@@ -564,55 +558,55 @@
     tslib "^2.3.0"
     yargs-parser "21.1.1"
 
-"@nx/nx-darwin-arm64@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.8.2.tgz#16b20a4aac4228f30124551a1eceb03d5f8330e7"
-  integrity sha512-t+bmCn6sRPNGU6hnSyWNvbQYA/KgsxGZKYlaCLRwkNhI2akModcBUqtktJzCKd1XHDqs6EkEFBWjFr8/kBEkSg==
+"@nx/nx-darwin-arm64@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.8.4.tgz#80a8dfa808d3e0749ac2a7b90683ca9dfd38f999"
+  integrity sha512-8Y7+4wj1qoZsuDRpnuiHzSIsMt3VqtJ0su8dgd/MyGccvvi4pndan2R5yTiVw/wmbMxtBmZ6PO6Z8dgSIrMVog==
 
-"@nx/nx-darwin-x64@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-20.8.2.tgz#06a203a695509e4a6f05a82cb40cc00438a19b3a"
-  integrity sha512-pt/wmDLM31Es8/EzazlyT5U+ou2l60rfMNFGCLqleHEQ0JUTc0KWnOciBLbHIQFiPsCQZJFEKyfV5V/ncePmmw==
+"@nx/nx-darwin-x64@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-20.8.4.tgz#59a2a7ca04c45648e4829cbc453e53dbef654317"
+  integrity sha512-2lfuxRc56QWnAysMhcD03tpCPiRzV1+foUq0MhV2sSBIybXmgV4wHLkPZNhlBCl4FNXrWiZiN1OJ2X9AGiOdug==
 
-"@nx/nx-freebsd-x64@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.8.2.tgz#c7c9ae6e331ca97571f6a048c0f69aa6c5fd2479"
-  integrity sha512-joZxFbgJfkHkB9uMIJr73Gpnm9pnpvr0XKGbWC409/d2x7q1qK77tKdyhGm+A3+kaZFwstNVPmCUtUwJYyU6LA==
+"@nx/nx-freebsd-x64@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.8.4.tgz#3905826ac68a0bc226266b858564b1e68c7223af"
+  integrity sha512-99vnUXZy+OUBHU+8Yhabre2qafepKg9GKkQkhmXvJGqOmuIsepK7wirUFo2PiVM8YhS6UV2rv6hKAZcQ7skYyg==
 
-"@nx/nx-linux-arm-gnueabihf@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.8.2.tgz#a6ae89115efb7601baa4c3421649ee785d6aa3a9"
-  integrity sha512-98O/qsxn4vIMPY/FyzvmVrl7C5yFhCUVk0/4PF+PA2SvtQ051L1eMRY6bq/lb69qfN6szJPZ41PG5mPx0NeLZw==
+"@nx/nx-linux-arm-gnueabihf@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.8.4.tgz#8c3dc73f17f064e10f98baca4f704fb1c015ebee"
+  integrity sha512-dht73zpnpzEUEzMHFQs4mfiwZH3WcJgQNWkD5p7WkeJewHq2Yyd0eG5Jg3kB7wnFtwPUV1eNJRM5rephgylkLA==
 
-"@nx/nx-linux-arm64-gnu@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.8.2.tgz#e9a4676d830783ecad5d5bfaf7bf2579c519321c"
-  integrity sha512-h6a+HxwfSpxsi4KpxGgPh9GDBmD2E+XqGCdfYpobabxqEBvlnIlJyuDhlRR06cTWpuNXHpRdrVogmV6m/YbtDg==
+"@nx/nx-linux-arm64-gnu@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.8.4.tgz#986a01154212da2b9946117ae1b5bd4aa1d00775"
+  integrity sha512-syXxbJZ0yPaqzVmB28QJgUtaarSiW/PQmv/5Z2Ps8rCi7kYylISPVNjP1NNiIOcGDRWbHqoBfM0bEGPfSp0rBQ==
 
-"@nx/nx-linux-arm64-musl@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.8.2.tgz#621657dc85c1cb042102f4ed4976cc5823fccea1"
-  integrity sha512-4Ev+jM0VAxDHV/dFgMXjQTCXS4I8W4oMe7FSkXpG8RUn6JK659DC8ExIDPoGIh+Cyqq6r6mw1CSia+ciQWICWQ==
+"@nx/nx-linux-arm64-musl@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.8.4.tgz#2c302efd47bd117cadbf2a2e6bf2aad7772665c4"
+  integrity sha512-AlZZFolS/S0FahRKG7rJ0Z9CgmIkyzHgGaoy3qNEMDEjFhR3jt2ZZSLp90W7zjgrxojOo90ajNMrg2UmtcQRDA==
 
-"@nx/nx-linux-x64-gnu@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.8.2.tgz#2b7b893a931b26a8688304d5352bdef0a2431194"
-  integrity sha512-nR0ev+wxu+nQYRd7bhqggOxK7UfkV6h+Ko1mumUFyrM5GvPpz/ELhjJFSnMcOkOMcvH0b6G5uTBJvN1XWCkbmg==
+"@nx/nx-linux-x64-gnu@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.8.4.tgz#8939af035b60b333c6b9e2a6bdfbe9365b559a1a"
+  integrity sha512-MSu+xVNdR95tuuO+eL/a/ZeMlhfrZ627On5xaCZXnJ+lFxNg/S4nlKZQk0Eq5hYALCd/GKgFGasRdlRdOtvGPg==
 
-"@nx/nx-linux-x64-musl@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.8.2.tgz#4188df5b222d6f42fff1e436d494a46af1d30b0b"
-  integrity sha512-ost41l5yc2aq2Gc9bMMpaPi/jkXqbXEMEPHrxWKuKmaek3K2zbVDQzvBBNcQKxf/mlCsrqN4QO0mKYSRRqag5A==
+"@nx/nx-linux-x64-musl@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.8.4.tgz#5ac14b362cba6d750ae33fa2ef94e8e76dd44c8e"
+  integrity sha512-KxpQpyLCgIIHWZ4iRSUN9ohCwn1ZSDASbuFCdG3mohryzCy8WrPkuPcb+68J3wuQhmA5w//Xpp/dL0hHoit9zQ==
 
-"@nx/nx-win32-arm64-msvc@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.8.2.tgz#6d2122a1c827c100e89698f4a878410833911748"
-  integrity sha512-0SEOqT/daBG5WtM9vOGilrYaAuf1tiALdrFavY62+/arXYxXemUKmRI5qoKDTnvoLMBGkJs6kxhMO5b7aUXIvQ==
+"@nx/nx-win32-arm64-msvc@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.8.4.tgz#f535e90325f6075c43fa5c535a079e02f9753a72"
+  integrity sha512-ffLBrxM9ibk+eWSY995kiFFRTSRb9HkD5T1s/uZyxV6jfxYPaZDBAWAETDneyBXps7WtaOMu+kVZlXQ3X+TfIA==
 
-"@nx/nx-win32-x64-msvc@20.8.2":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.8.2.tgz#60f4c381ad62369ff7ede9336d92262352514bc1"
-  integrity sha512-iIsY+tVqes/NOqTbJmggL9Juie/iaDYlWgXA9IUv88FE9thqWKhVj4/tCcPjsOwzD+1SVna3YISEEFsx5UV4ew==
+"@nx/nx-win32-x64-msvc@20.8.4":
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.8.4.tgz#4f11cc0ce9ef6ace20764b1a2897e929f1c17844"
+  integrity sha512-JxuuZc4h8EBqoYAiRHwskimpTJx70yn4lhIRFBoW5ICkxXW1Rw0yip/1UVsWRHXg/x9BxmH7VVazdfaQWmGu6A==
 
 "@octokit/auth-token@^4.0.0":
   version "4.0.0"
@@ -719,110 +713,130 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@rollup/rollup-android-arm-eabi@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.1.tgz#7d41dc45adcfcb272504ebcea9c8a5b2c659e963"
-  integrity sha512-HJXwzoZN4eYTdD8bVV22DN8gsPCAj3V20NHKOs8ezfXanGpmVPR7kalUHd+Y31IJp9stdB87VKPFbsGY3H/2ag==
+"@rollup/rollup-android-arm-eabi@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz#d03ba6ea54f9ec80688d153763cd325a2d2a5af6"
+  integrity sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==
 
-"@rollup/rollup-android-arm64@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.1.tgz#6c708fae2c9755e994c42d56c34a94cb77020650"
-  integrity sha512-PZlsJVcjHfcH53mOImyt3bc97Ep3FJDXRpk9sMdGX0qgLmY0EIWxCag6EigerGhLVuL8lDVYNnSo8qnTElO4xw==
+"@rollup/rollup-android-arm64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz#db5e36aa8a955b4b5e0b024d671230edc5cdc191"
+  integrity sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==
 
-"@rollup/rollup-darwin-arm64@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.1.tgz#85ccf92ab114e434c83037a175923a525635cbb4"
-  integrity sha512-xc6i2AuWh++oGi4ylOFPmzJOEeAa2lJeGUGb4MudOtgfyyjr4UPNK+eEWTPLvmPJIY/pgw6ssFIox23SyrkkJw==
+"@rollup/rollup-darwin-arm64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz#1ed1c43922e7b9b5d020ef65d8402e3c81edc86e"
+  integrity sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==
 
-"@rollup/rollup-darwin-x64@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.1.tgz#0af089f3d658d05573208dabb3a392b44d7f4630"
-  integrity sha512-2ofU89lEpDYhdLAbRdeyz/kX3Y2lpYc6ShRnDjY35bZhd2ipuDMDi6ZTQ9NIag94K28nFMofdnKeHR7BT0CATw==
+"@rollup/rollup-darwin-x64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz#0a86e782bf7a546e74f531e395e24fdb45c83527"
+  integrity sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==
 
-"@rollup/rollup-freebsd-arm64@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.1.tgz#46c22a16d18180e99686647543335567221caa9c"
-  integrity sha512-wOsE6H2u6PxsHY/BeFHA4VGQN3KUJFZp7QJBmDYI983fgxq5Th8FDkVuERb2l9vDMs1D5XhOrhBrnqcEY6l8ZA==
+"@rollup/rollup-freebsd-arm64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz#82fa51c540185b5063c8b3c63aac79b15f2801ad"
+  integrity sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==
 
-"@rollup/rollup-freebsd-x64@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.1.tgz#819ffef2f81891c266456952962a13110c8e28b5"
-  integrity sha512-A/xeqaHTlKbQggxCqispFAcNjycpUEHP52mwMQZUNqDUJFFYtPHCXS1VAG29uMlDzIVr+i00tSFWFLivMcoIBQ==
+"@rollup/rollup-freebsd-x64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz#df1d73b567fd62e0cf21c9b57dff7f44bfd69638"
+  integrity sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.1.tgz#7fe283c14793e607e653a3214b09f8973f08262a"
-  integrity sha512-54v4okehwl5TaSIkpp97rAHGp7t3ghinRd/vyC1iXqXMfjYUTm7TfYmCzXDoHUPTTf36L8pr0E7YsD3CfB3ZDg==
+"@rollup/rollup-linux-arm-gnueabihf@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz#a585ba0418027a5b567693db3982e5e57544a4c7"
+  integrity sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==
 
-"@rollup/rollup-linux-arm-musleabihf@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.1.tgz#066e92eb22ea30560414ec800a6d119ba0b435ac"
-  integrity sha512-p/LaFyajPN/0PUHjv8TNyxLiA7RwmDoVY3flXHPSzqrGcIp/c2FjwPPP5++u87DGHtw+5kSH5bCJz0mvXngYxw==
+"@rollup/rollup-linux-arm-musleabihf@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz#1326f0db22b690a92efd8eaa06e92268dc7d1bb6"
+  integrity sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==
 
-"@rollup/rollup-linux-arm64-gnu@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.1.tgz#480d518ea99a8d97b2a174c46cd55164f138cc37"
-  integrity sha512-2AbMhFFkTo6Ptna1zO7kAXXDLi7H9fGTbVaIq2AAYO7yzcAsuTNWPHhb2aTA6GPiP+JXh85Y8CiS54iZoj4opw==
+"@rollup/rollup-linux-arm64-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz#9491939f7cc43a5b26a877417faeafe69bac79ac"
+  integrity sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==
 
-"@rollup/rollup-linux-arm64-musl@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.1.tgz#ed7db3b8999b60dd20009ddf71c95f3af49423c8"
-  integrity sha512-Cgef+5aZwuvesQNw9eX7g19FfKX5/pQRIyhoXLCiBOrWopjo7ycfB292TX9MDcDijiuIJlx1IzJz3IoCPfqs9w==
+"@rollup/rollup-linux-arm64-musl@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz#a53d93dac32acc671324af1153930ab5a04d8639"
+  integrity sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.1.tgz#16a6927a35f5dbc505ff874a4e1459610c0c6f46"
-  integrity sha512-RPhTwWMzpYYrHrJAS7CmpdtHNKtt2Ueo+BlLBjfZEhYBhK00OsEqM08/7f+eohiF6poe0YRDDd8nAvwtE/Y62Q==
+"@rollup/rollup-linux-loong64-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz#db6e06173efc870be49a2df692d0c0607417a679"
+  integrity sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==
 
-"@rollup/rollup-linux-ppc64-gnu@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.1.tgz#a006700469be0041846c45b494c35754e6a04eea"
-  integrity sha512-eSGMVQw9iekut62O7eBdbiccRguuDgiPMsw++BVUg+1K7WjZXHOg/YOT9SWMzPZA+w98G+Fa1VqJgHZOHHnY0Q==
+"@rollup/rollup-linux-loong64-musl@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz#a60734a3de407bcf4bfe44d0b64222c0b9fb30bc"
+  integrity sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==
 
-"@rollup/rollup-linux-riscv64-gnu@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.1.tgz#0fcc45b2ec8a0e54218ca48849ea6d596f53649c"
-  integrity sha512-S208ojx8a4ciIPrLgazF6AgdcNJzQE4+S9rsmOmDJkusvctii+ZvEuIC4v/xFqzbuP8yDjn73oBlNDgF6YGSXQ==
+"@rollup/rollup-linux-ppc64-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz#28a67e15d7ba8630ef044980a39626e0627d6e73"
+  integrity sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==
 
-"@rollup/rollup-linux-riscv64-musl@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.1.tgz#d6e617eec9fe6f5859ee13fad435a16c42b469f2"
-  integrity sha512-3Ag8Ls1ggqkGUvSZWYcdgFwriy2lWo+0QlYgEFra/5JGtAd6C5Hw59oojx1DeqcA2Wds2ayRgvJ4qxVTzCHgzg==
+"@rollup/rollup-linux-ppc64-musl@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz#77bb553a514942af54070756763dbb44c9c6cb2b"
+  integrity sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==
 
-"@rollup/rollup-linux-s390x-gnu@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.1.tgz#b147760d63c6f35b4b18e6a25a2a760dd3ea0c05"
-  integrity sha512-t9YrKfaxCYe7l7ldFERE1BRg/4TATxIg+YieHQ966jwvo7ddHJxPj9cNFWLAzhkVsbBvNA4qTbPVNsZKBO4NSg==
+"@rollup/rollup-linux-riscv64-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz#ef9f31b917e3b310eac5b86d3b6626df7e543e3d"
+  integrity sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==
 
-"@rollup/rollup-linux-x64-gnu@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.1.tgz#fc0be1da374f85e7e85dccaf1ff12d7cfc9fbe3d"
-  integrity sha512-MCgtFB2+SVNuQmmjHf+wfI4CMxy3Tk8XjA5Z//A0AKD7QXUYFMQcns91K6dEHBvZPCnhJSyDWLApk40Iq/H3tA==
+"@rollup/rollup-linux-riscv64-musl@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz#68cf61a2fc02171d1fa62568b73c1d942f82e80c"
+  integrity sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==
 
-"@rollup/rollup-linux-x64-musl@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.1.tgz#54c79932e0f9a3c992b034c82325be3bcde0d067"
-  integrity sha512-nEvqG+0jeRmqaUMuwzlfMKwcIVffy/9KGbAGyoa26iu6eSngAYQ512bMXuqqPrlTyfqdlB9FVINs93j534UJrg==
+"@rollup/rollup-linux-s390x-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz#92d393ca47da0d03d1c1cffb3d7340f26c3a53d2"
+  integrity sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==
 
-"@rollup/rollup-openharmony-arm64@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.1.tgz#fc48e74d413623ac02c1d521bec3e5e784488fdc"
-  integrity sha512-RDsLm+phmT3MJd9SNxA9MNuEAO/J2fhW8GXk62G/B4G7sLVumNFbRwDL6v5NrESb48k+QMqdGbHgEtfU0LCpbA==
+"@rollup/rollup-linux-x64-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz#f6e5c5c51f96ae298617fa26da54675acd60e3bc"
+  integrity sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==
 
-"@rollup/rollup-win32-arm64-msvc@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.1.tgz#8ce3d1181644406362cf1e62c90e88ab083e02bb"
-  integrity sha512-hpZB/TImk2FlAFAIsoElM3tLzq57uxnGYwplg6WDyAxbYczSi8O2eQ+H2Lx74504rwKtZ3N2g4bCUkiamzS6TQ==
+"@rollup/rollup-linux-x64-musl@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz#227a949c481909c781d8a39c280f75553cdd16bc"
+  integrity sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==
 
-"@rollup/rollup-win32-ia32-msvc@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.1.tgz#dd2dfc896eac4b2689d55f01c6d51c249263f805"
-  integrity sha512-SXjv8JlbzKM0fTJidX4eVsH+Wmnp0/WcD8gJxIZyR6Gay5Qcsmdbi9zVtnbkGPG8v2vMR1AD06lGWy5FLMcG7A==
+"@rollup/rollup-openbsd-x64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz#f57241ebdb73d3bc236e7b1252988408b2139c13"
+  integrity sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==
 
-"@rollup/rollup-win32-x64-msvc@4.50.1":
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.1.tgz#13f758c97b9fbbac56b6928547a3ff384e7cfb3e"
-  integrity sha512-StxAO/8ts62KZVRAm4JZYq9+NqNsV7RvimNK+YM7ry//zebEH6meuugqW/P5OFUCjyQgui+9fUxT6d5NShvMvA==
+"@rollup/rollup-openharmony-arm64@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz#3a9ffe5af71e8316dd2716b57dd64287a8c1fa0b"
+  integrity sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==
+
+"@rollup/rollup-win32-arm64-msvc@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz#7d4a40396ae79ebc1e3636c1d566c7d1838b800c"
+  integrity sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==
+
+"@rollup/rollup-win32-ia32-msvc@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz#f234ab80141da45ebe85727f714eb20de2e72c2a"
+  integrity sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==
+
+"@rollup/rollup-win32-x64-gnu@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz#5d5a664c23c8ff0526b9abd703b50ffe09703c2a"
+  integrity sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==
+
+"@rollup/rollup-win32-x64-msvc@4.63.1":
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz#cd19d691330cbd52ebb13620acb6cf7140b95e80"
+  integrity sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==
 
 "@sigstore/bundle@^2.3.2":
   version "2.3.2"
@@ -837,9 +851,9 @@
   integrity sha512-JzBqdVIyqm2FRQCulY6nbQzMpJJpSiJ8XXWMhtOX9eKgaXXpfNOF53lzQEjIydlStnd/eFtuC1dW4VYdD93oRg==
 
 "@sigstore/protobuf-specs@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz#5becf88e494a920f548d0163e2978f81b44b7d6f"
-  integrity sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.3.3.tgz#7dd46d68b76c322873a2ef7581ed955af6f4dcde"
+  integrity sha512-RpacQhBlwpBWd7KEJsRKcBQalbV28fvkxwTOJIqhIuDysMMaJW47V4OqW30iJB9uRpqOSxxEAQFdr8tTattReQ==
 
 "@sigstore/sign@^2.3.2":
   version "2.3.2"
@@ -871,14 +885,14 @@
     "@sigstore/protobuf-specs" "^0.3.2"
 
 "@sinclair/typebox@^0.27.8":
-  version "0.27.8"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
-  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+  version "0.27.12"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.12.tgz#0cacd3cff047a32936b1ace47ea7c86eaab60a7f"
+  integrity sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==
 
 "@tsconfig/node10@^1.0.7":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
-  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.13.tgz#56105a9a8c786e8f15e35746879cf2d52275485b"
+  integrity sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==
 
 "@tsconfig/node12@^1.0.7":
   version "1.0.11"
@@ -916,26 +930,22 @@
     tslib "^2.4.0"
 
 "@types/chai@^5.2.2":
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.2.tgz#6f14cea18180ffc4416bc0fd12be05fdd73bdd6b"
-  integrity sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
   dependencies:
     "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
 
 "@types/deep-eql@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/estree@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
-  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-
-"@types/estree@^1.0.0":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
-  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
+"@types/estree@1.0.9", "@types/estree@^1.0.0":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/luxon@3.7.1":
   version "3.7.1"
@@ -973,11 +983,6 @@
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
   integrity sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==
-
-"@types/uuid@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
-  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@vitest/coverage-v8@3.2.4":
   version "3.2.4"
@@ -1018,10 +1023,17 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
+"@vitest/pretty-format@3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
   integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/pretty-format@^3.2.4":
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.7.tgz#2a7b593f8e007e9d8ef7e7343aa30ec73fdeaf29"
+  integrity sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==
   dependencies:
     tinyrainbow "^2.0.0"
 
@@ -1093,26 +1105,33 @@ abbrev@^2.0.0:
   integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
 
 acorn-walk@^8.1.1:
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
-  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
   dependencies:
     acorn "^8.11.0"
 
 acorn@^8.11.0, acorn@^8.4.1:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
-  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
+  integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 agent-base@^7.1.0, agent-base@^7.1.2:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
-  integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1139,10 +1158,10 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-regex@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
-  integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
+ansi-regex@^6.2.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.3.0.tgz#247c8e7b70a1a43b10ce14c0226fcbf58e8815d5"
+  integrity sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
@@ -1157,9 +1176,9 @@ ansi-styles@^5.0.0:
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
-  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 aproba@2.0.0:
   version "2.0.0"
@@ -1214,15 +1233,15 @@ assertion-error@^2.0.1:
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 ast-v8-to-istanbul@^0.3.3:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.5.tgz#9fba217c272dd8c2615603da5de3e1a460b4b9af"
-  integrity sha512-9SdXjNheSiE8bALAQCQQuT6fgQaoxJh7IRYrRGZ8/9nv8WhJeC1aXAwN8TbaOssGOukUvyvnkgD9+Yuykvl1aA==
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz#8eb1b7c86ef8499859be761b17ffd91406c0c36f"
+  integrity sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==
   dependencies:
-    "@jridgewell/trace-mapping" "^0.3.30"
+    "@jridgewell/trace-mapping" "^0.3.31"
     estree-walker "^3.0.3"
-    js-tokens "^9.0.1"
+    js-tokens "^10.0.0"
 
-async@^3.2.3:
+async@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
@@ -1233,18 +1252,24 @@ asynckit@^0.4.0:
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 axios@^1.8.3:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.0.tgz#11248459be05a5ee493485628fa0e4323d0abfc3"
-  integrity sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.20.0.tgz#515513445aa60e71d04b6521ca6210829ccb4786"
+  integrity sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.6"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -1276,19 +1301,26 @@ bl@^4.0.3, bl@^4.1.0:
     readable-stream "^3.4.0"
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+brace-expansion@^2.0.1, brace-expansion@^2.0.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
+
+brace-expansion@^5.0.8:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
+  dependencies:
+    balanced-match "^4.0.2"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -1377,7 +1409,7 @@ chalk@4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1385,15 +1417,15 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+chardet@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.2.0.tgz#005d664f2cbd4961888d2e2c32c5a69e59d8eec4"
+  integrity sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==
 
 check-error@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
-  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -1406,9 +1438,9 @@ ci-info@^3.2.0:
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 ci-info@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.3.0.tgz#c39b1013f8fdbd28cd78e62318357d02da160cd7"
-  integrity sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -1637,7 +1669,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.3:
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1661,17 +1693,10 @@ dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.1.1, debug@^4.3.4:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
-  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
-  dependencies:
-    ms "^2.1.3"
-
-debug@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
-  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+debug@4, debug@^4.1.1, debug@^4.3.4, debug@^4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -1731,9 +1756,9 @@ diff-sequences@^29.6.3:
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
+  integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -1803,9 +1828,9 @@ encoding@^0.1.13:
     iconv-lite "^0.6.2"
 
 end-of-stream@^1.4.1:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
   dependencies:
     once "^1.4.0"
 
@@ -1832,9 +1857,9 @@ err-code@^2.0.2:
   integrity sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==
 
 error-ex@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
-  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.4.tgz#b3a8d8bb6f92eecc1629e3e27d3c8607a8a32414"
+  integrity sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -1854,9 +1879,9 @@ es-module-lexer@^1.7.0:
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
-  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
 
@@ -1870,37 +1895,37 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-esbuild@^0.25.0:
-  version "0.25.9"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.9.tgz#15ab8e39ae6cdc64c24ff8a2c0aef5b3fd9fa976"
-  integrity sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==
+"esbuild@^0.27.0 || ^0.28.0":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.2.tgz#0f43bd1bad955b72d24e2261e3abe5957ccf0816"
+  integrity sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==
   optionalDependencies:
-    "@esbuild/aix-ppc64" "0.25.9"
-    "@esbuild/android-arm" "0.25.9"
-    "@esbuild/android-arm64" "0.25.9"
-    "@esbuild/android-x64" "0.25.9"
-    "@esbuild/darwin-arm64" "0.25.9"
-    "@esbuild/darwin-x64" "0.25.9"
-    "@esbuild/freebsd-arm64" "0.25.9"
-    "@esbuild/freebsd-x64" "0.25.9"
-    "@esbuild/linux-arm" "0.25.9"
-    "@esbuild/linux-arm64" "0.25.9"
-    "@esbuild/linux-ia32" "0.25.9"
-    "@esbuild/linux-loong64" "0.25.9"
-    "@esbuild/linux-mips64el" "0.25.9"
-    "@esbuild/linux-ppc64" "0.25.9"
-    "@esbuild/linux-riscv64" "0.25.9"
-    "@esbuild/linux-s390x" "0.25.9"
-    "@esbuild/linux-x64" "0.25.9"
-    "@esbuild/netbsd-arm64" "0.25.9"
-    "@esbuild/netbsd-x64" "0.25.9"
-    "@esbuild/openbsd-arm64" "0.25.9"
-    "@esbuild/openbsd-x64" "0.25.9"
-    "@esbuild/openharmony-arm64" "0.25.9"
-    "@esbuild/sunos-x64" "0.25.9"
-    "@esbuild/win32-arm64" "0.25.9"
-    "@esbuild/win32-ia32" "0.25.9"
-    "@esbuild/win32-x64" "0.25.9"
+    "@esbuild/aix-ppc64" "0.28.2"
+    "@esbuild/android-arm" "0.28.2"
+    "@esbuild/android-arm64" "0.28.2"
+    "@esbuild/android-x64" "0.28.2"
+    "@esbuild/darwin-arm64" "0.28.2"
+    "@esbuild/darwin-x64" "0.28.2"
+    "@esbuild/freebsd-arm64" "0.28.2"
+    "@esbuild/freebsd-x64" "0.28.2"
+    "@esbuild/linux-arm" "0.28.2"
+    "@esbuild/linux-arm64" "0.28.2"
+    "@esbuild/linux-ia32" "0.28.2"
+    "@esbuild/linux-loong64" "0.28.2"
+    "@esbuild/linux-mips64el" "0.28.2"
+    "@esbuild/linux-ppc64" "0.28.2"
+    "@esbuild/linux-riscv64" "0.28.2"
+    "@esbuild/linux-s390x" "0.28.2"
+    "@esbuild/linux-x64" "0.28.2"
+    "@esbuild/netbsd-arm64" "0.28.2"
+    "@esbuild/netbsd-x64" "0.28.2"
+    "@esbuild/openbsd-arm64" "0.28.2"
+    "@esbuild/openbsd-x64" "0.28.2"
+    "@esbuild/openharmony-arm64" "0.28.2"
+    "@esbuild/sunos-x64" "0.28.2"
+    "@esbuild/win32-arm64" "0.28.2"
+    "@esbuild/win32-ia32" "0.28.2"
+    "@esbuild/win32-x64" "0.28.2"
 
 escalade@^3.1.1:
   version "3.2.0"
@@ -1945,23 +1970,14 @@ execa@5.0.0:
     strip-final-newline "^2.0.0"
 
 expect-type@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
-  integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 exponential-backoff@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
-  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
-
-external-editor@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
-  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.3.tgz#51cf92c1c0493c766053f9d3abee4434c244d2f6"
+  integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
 fast-deep-equal@3.1.3:
   version "3.1.3"
@@ -1981,9 +1997,9 @@ figures@3.2.0, figures@^3.0.0:
     escape-string-regexp "^1.0.5"
 
 filelist@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
-  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.6.tgz#1e8870942a7c636c862f7c49b9394937b6a995a3"
+  integrity sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==
   dependencies:
     minimatch "^5.0.1"
 
@@ -2007,29 +2023,29 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 foreground-child@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
-  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
   dependencies:
-    cross-spawn "^7.0.0"
+    cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+form-data@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
-    mime-types "^2.1.12"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 front-matter@^4.0.2:
   version "4.0.2"
@@ -2044,9 +2060,9 @@ fs-constants@^1.0.0:
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@^11.2.0:
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.1.tgz#ba7a1f97a85f94c6db2e52ff69570db3671d5a74"
-  integrity sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.4.0.tgz#f88ed6d180ac9e14b61b08e679468f0b1b6b4730"
+  integrity sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -2190,9 +2206,9 @@ glob-parent@6.0.2:
     is-glob "^4.0.3"
 
 glob@^10.2.2, glob@^10.3.10, glob@^10.4.1:
-  version "10.4.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
-  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
   dependencies:
     foreground-child "^3.1.0"
     jackspeak "^3.1.2"
@@ -2222,9 +2238,9 @@ graceful-fs@4.2.11, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 handlebars@^4.7.7:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"
@@ -2260,10 +2276,10 @@ has-unicode@2.0.1:
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
   integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
 
-hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+hasown@^2.0.2, hasown@^2.0.3, hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -2292,9 +2308,9 @@ html-escaper@^2.0.0:
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 http-cache-semantics@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
-  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
 
 http-proxy-agent@^7.0.0:
   version "7.0.2"
@@ -2303,6 +2319,14 @@ http-proxy-agent@^7.0.0:
   dependencies:
     agent-base "^7.1.0"
     debug "^4.3.4"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 https-proxy-agent@^7.0.1:
   version "7.0.6"
@@ -2317,17 +2341,17 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-iconv-lite@^0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
 iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.3.tgz#84ee12f963e7de50bc01a13e160a078b3b0f415f"
+  integrity sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
@@ -2349,9 +2373,9 @@ ignore@^5.0.4:
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 import-fresh@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
-  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -2403,15 +2427,15 @@ init-package-json@6.0.3:
     validate-npm-package-name "^5.0.0"
 
 inquirer@^8.2.4:
-  version "8.2.6"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.6.tgz#733b74888195d8d400a67ac332011b5fae5ea562"
-  integrity sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==
+  version "8.2.7"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.7.tgz#62f6b931a9b7f8735dc42db927316d8fb6f71de8"
+  integrity sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==
   dependencies:
+    "@inquirer/external-editor" "^1.0.0"
     ansi-escapes "^4.2.1"
     chalk "^4.1.1"
     cli-cursor "^3.1.0"
     cli-width "^3.0.0"
-    external-editor "^3.0.3"
     figures "^3.0.0"
     lodash "^4.17.21"
     mute-stream "0.0.8"
@@ -2423,13 +2447,10 @@ inquirer@^8.2.4:
     through "^2.3.6"
     wrap-ansi "^6.0.1"
 
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
+ip-address@^10.1.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.5.0.tgz#fcd6d7dfe9e68416b7cb71afe9bc960b3e38c13b"
+  integrity sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2443,12 +2464,12 @@ is-ci@3.0.1:
   dependencies:
     ci-info "^3.2.0"
 
-is-core-module@^2.16.0, is-core-module@^2.5.0:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
-  integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
+is-core-module@^2.16.1, is-core-module@^2.5.0:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
   dependencies:
-    hasown "^2.0.2"
+    hasown "^2.0.3"
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
@@ -2500,9 +2521,9 @@ is-plain-object@^2.0.4:
     isobject "^3.0.1"
 
 is-ssh@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.4.0.tgz#4f8220601d2839d8fa624b3106f8e8884f01b8b2"
-  integrity sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.4.1.tgz#76de1cdbe8f92a8b905d1a172b6bc09704c20396"
+  integrity sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==
   dependencies:
     protocols "^2.0.1"
 
@@ -2546,9 +2567,9 @@ isexe@^2.0.0:
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 isexe@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
-  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.5.tgz#42e368f68d5e10dadfee4fda7b550bc2d8892dc9"
+  integrity sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==
 
 isobject@^3.0.1:
   version "3.0.1"
@@ -2596,14 +2617,13 @@ jackspeak@^3.1.2:
     "@pkgjs/parseargs" "^0.11.0"
 
 jake@^10.8.5:
-  version "10.9.2"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.2.tgz#6ae487e6a69afec3a5e167628996b59f35ae2b7f"
-  integrity sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.4.tgz#d626da108c63d5cfb00ab5c25fadc7e0084af8e6"
+  integrity sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==
   dependencies:
-    async "^3.2.3"
-    chalk "^4.0.2"
+    async "^3.2.6"
     filelist "^1.0.4"
-    minimatch "^3.1.2"
+    picocolors "^1.1.1"
 
 "jest-diff@>=29.4.3 < 30", jest-diff@^29.4.1:
   version "29.7.0"
@@ -2620,6 +2640,11 @@ jest-get-type@^29.6.3:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2630,7 +2655,7 @@ js-tokens@^9.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
   integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -2638,17 +2663,19 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
     argparse "^2.0.1"
 
 js-yaml@^3.10.0, js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.2.tgz#3f83823ac6be17f570f23b2ecdef3777ff5ea364"
+  integrity sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
+js-yaml@^4.1.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.2.tgz#8e44fb14a2643c59726bb15787b5f1512cb3d3fb"
+  integrity sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==
+  dependencies:
+    argparse "^2.0.1"
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -2686,9 +2713,9 @@ jsonc-parser@3.2.0:
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
 jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.1.tgz#b6e31717f22cc37330b081ce0051ed5de53af2f6"
+  integrity sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==
   dependencies:
     universalify "^2.0.0"
   optionalDependencies:
@@ -2873,9 +2900,9 @@ lodash.ismatch@^4.4.0:
   integrity sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==
 
 lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"
@@ -2908,9 +2935,9 @@ luxon@3.7.2:
   integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
 
 magic-string@^0.30.17:
-  version "0.30.19"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.19.tgz#cebe9f104e565602e5d2098c5f2e79a77cc86da9"
-  integrity sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
@@ -3003,7 +3030,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -3034,33 +3061,40 @@ minimatch@9.0.3:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^3.0.4, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^10.2.2:
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
+  integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
+  dependencies:
+    brace-expansion "^5.0.8"
+
+minimatch@^3.0.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
+  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
   dependencies:
     brace-expansion "^2.0.1"
 
 minimatch@^8.0.2:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
-  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.7.tgz#954766e22da88a3e0a17ad93b58c15c9d8a579de"
+  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
   dependencies:
     brace-expansion "^2.0.1"
 
 minimatch@^9.0.0, minimatch@^9.0.4:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^2.0.2"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -3095,9 +3129,9 @@ minipass-fetch@^3.0.0:
     encoding "^0.1.13"
 
 minipass-flush@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
-  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.7.tgz#145c383d5ae294b36030aa80d4e872d08bebcb73"
+  integrity sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==
   dependencies:
     minipass "^3.0.0"
 
@@ -3133,9 +3167,9 @@ minipass@^5.0.0:
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.2, minipass@^7.0.3, minipass@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
-  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
@@ -3161,9 +3195,9 @@ moment@2.30.1:
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moo@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
-  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.3.tgz#dfcdb40ff6f1a03c34af5df7f9717cecfa88c38c"
+  integrity sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -3191,10 +3225,10 @@ mute-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 nearley@2.20.1:
   version "2.20.1"
@@ -3358,9 +3392,9 @@ npm-run-path@^4.0.1:
     path-key "^3.0.0"
 
 "nx@>=17.1.2 < 21":
-  version "20.8.2"
-  resolved "https://registry.yarnpkg.com/nx/-/nx-20.8.2.tgz#c70f504fee1804015034d0f7b2c51871a25bda3a"
-  integrity sha512-mDKpbH3vEpUFDx0rrLh+tTqLq1PYU8KiD/R7OVZGd1FxQxghx2HOl32MiqNsfPcw6AvKlXhslbwIESV+N55FLQ==
+  version "20.8.4"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-20.8.4.tgz#bdbb4e41963fa7833c2aa3c972b5832f8b56983d"
+  integrity sha512-/++x0OM3/UTmDR+wmPeV13tSxeTr+QGzj3flgtH9DiOPmQnn2CjHWAMZiOhcSh/hHoE/V3ySL4757InQUsVtjQ==
   dependencies:
     "@napi-rs/wasm-runtime" "0.2.4"
     "@yarnpkg/lockfile" "^1.1.0"
@@ -3397,16 +3431,16 @@ npm-run-path@^4.0.1:
     yargs "^17.6.2"
     yargs-parser "21.1.1"
   optionalDependencies:
-    "@nx/nx-darwin-arm64" "20.8.2"
-    "@nx/nx-darwin-x64" "20.8.2"
-    "@nx/nx-freebsd-x64" "20.8.2"
-    "@nx/nx-linux-arm-gnueabihf" "20.8.2"
-    "@nx/nx-linux-arm64-gnu" "20.8.2"
-    "@nx/nx-linux-arm64-musl" "20.8.2"
-    "@nx/nx-linux-x64-gnu" "20.8.2"
-    "@nx/nx-linux-x64-musl" "20.8.2"
-    "@nx/nx-win32-arm64-msvc" "20.8.2"
-    "@nx/nx-win32-x64-msvc" "20.8.2"
+    "@nx/nx-darwin-arm64" "20.8.4"
+    "@nx/nx-darwin-x64" "20.8.4"
+    "@nx/nx-freebsd-x64" "20.8.4"
+    "@nx/nx-linux-arm-gnueabihf" "20.8.4"
+    "@nx/nx-linux-arm64-gnu" "20.8.4"
+    "@nx/nx-linux-arm64-musl" "20.8.4"
+    "@nx/nx-linux-x64-gnu" "20.8.4"
+    "@nx/nx-linux-x64-musl" "20.8.4"
+    "@nx/nx-win32-arm64-msvc" "20.8.4"
+    "@nx/nx-win32-x64-msvc" "20.8.4"
 
 once@^1.4.0:
   version "1.4.0"
@@ -3459,11 +3493,6 @@ ora@^5.4.1:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -3615,9 +3644,9 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     lines-and-columns "^1.1.6"
 
 parse-path@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.0.0.tgz#605a2d58d0a749c8594405d8cc3a2bf76d16099b"
-  integrity sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.1.0.tgz#41fb513cb122831807a4c7b29c8727947a09d8c6"
+  integrity sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==
   dependencies:
     protocols "^2.0.0"
 
@@ -3673,15 +3702,15 @@ pathval@^2.0.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^4.0.2, picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.7.tgz#6313360034ccb36b3dc61ecbdff78121f90fe21f"
+  integrity sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==
 
 pify@5.0.0:
   version "5.0.0"
@@ -3711,19 +3740,19 @@ pkg-dir@^4.2.0:
     find-up "^4.0.0"
 
 postcss-selector-parser@^6.0.10:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz#fdec4ca80f5781bd216ca9bf89a2a0fccfffa5f0"
+  integrity sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
 postcss@^8.5.6:
-  version "8.5.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
-  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
   dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.17"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -3787,14 +3816,14 @@ promzard@^1.0.0:
     read "^3.0.1"
 
 protocols@^2.0.0, protocols@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.1.tgz#8f155da3fc0f32644e83c5782c8e8212ccf70a86"
-  integrity sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.2.tgz#822e8fcdcb3df5356538b3e91bfd890b067fd0a4"
+  integrity sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 quick-lru@^4.0.1:
   version "4.0.1"
@@ -3933,11 +3962,12 @@ resolve.exports@2.0.3:
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
 resolve@^1.10.0:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
-  integrity sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
   dependencies:
-    is-core-module "^2.16.0"
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -3967,33 +3997,38 @@ rimraf@^4.4.1:
     glob "^9.2.0"
 
 rollup@^4.43.0:
-  version "4.50.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.50.1.tgz#6f0717c34aacc65cc727eeaaaccc2afc4e4485fd"
-  integrity sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==
+  version "4.63.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.63.1.tgz#a9b96d5b2558d034babb12ad8b67a043bc870ac4"
+  integrity sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==
   dependencies:
-    "@types/estree" "1.0.8"
+    "@types/estree" "1.0.9"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.50.1"
-    "@rollup/rollup-android-arm64" "4.50.1"
-    "@rollup/rollup-darwin-arm64" "4.50.1"
-    "@rollup/rollup-darwin-x64" "4.50.1"
-    "@rollup/rollup-freebsd-arm64" "4.50.1"
-    "@rollup/rollup-freebsd-x64" "4.50.1"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.50.1"
-    "@rollup/rollup-linux-arm-musleabihf" "4.50.1"
-    "@rollup/rollup-linux-arm64-gnu" "4.50.1"
-    "@rollup/rollup-linux-arm64-musl" "4.50.1"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.50.1"
-    "@rollup/rollup-linux-ppc64-gnu" "4.50.1"
-    "@rollup/rollup-linux-riscv64-gnu" "4.50.1"
-    "@rollup/rollup-linux-riscv64-musl" "4.50.1"
-    "@rollup/rollup-linux-s390x-gnu" "4.50.1"
-    "@rollup/rollup-linux-x64-gnu" "4.50.1"
-    "@rollup/rollup-linux-x64-musl" "4.50.1"
-    "@rollup/rollup-openharmony-arm64" "4.50.1"
-    "@rollup/rollup-win32-arm64-msvc" "4.50.1"
-    "@rollup/rollup-win32-ia32-msvc" "4.50.1"
-    "@rollup/rollup-win32-x64-msvc" "4.50.1"
+    "@napi-rs/lzma-linux-x64-gnu" "1.5.1"
+    "@rollup/rollup-android-arm-eabi" "4.63.1"
+    "@rollup/rollup-android-arm64" "4.63.1"
+    "@rollup/rollup-darwin-arm64" "4.63.1"
+    "@rollup/rollup-darwin-x64" "4.63.1"
+    "@rollup/rollup-freebsd-arm64" "4.63.1"
+    "@rollup/rollup-freebsd-x64" "4.63.1"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.63.1"
+    "@rollup/rollup-linux-arm-musleabihf" "4.63.1"
+    "@rollup/rollup-linux-arm64-gnu" "4.63.1"
+    "@rollup/rollup-linux-arm64-musl" "4.63.1"
+    "@rollup/rollup-linux-loong64-gnu" "4.63.1"
+    "@rollup/rollup-linux-loong64-musl" "4.63.1"
+    "@rollup/rollup-linux-ppc64-gnu" "4.63.1"
+    "@rollup/rollup-linux-ppc64-musl" "4.63.1"
+    "@rollup/rollup-linux-riscv64-gnu" "4.63.1"
+    "@rollup/rollup-linux-riscv64-musl" "4.63.1"
+    "@rollup/rollup-linux-s390x-gnu" "4.63.1"
+    "@rollup/rollup-linux-x64-gnu" "4.63.1"
+    "@rollup/rollup-linux-x64-musl" "4.63.1"
+    "@rollup/rollup-openbsd-x64" "4.63.1"
+    "@rollup/rollup-openharmony-arm64" "4.63.1"
+    "@rollup/rollup-win32-arm64-msvc" "4.63.1"
+    "@rollup/rollup-win32-ia32-msvc" "4.63.1"
+    "@rollup/rollup-win32-x64-gnu" "4.63.1"
+    "@rollup/rollup-win32-x64-msvc" "4.63.1"
     fsevents "~2.3.2"
 
 run-async@^2.4.0:
@@ -4002,9 +4037,9 @@ run-async@^2.4.0:
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 rxjs@^7.5.5:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
-  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
     tslib "^2.1.0"
 
@@ -4018,7 +4053,7 @@ safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -4029,9 +4064,9 @@ safe-buffer@~5.2.0:
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -4104,11 +4139,11 @@ socks-proxy-agent@^8.0.3:
     socks "^2.8.3"
 
 socks@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.3.tgz#1ebd0f09c52ba95a09750afe3f3f9f724a800cb5"
-  integrity sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.9.tgz#aa5f130ca0f88a43fa44faf4869c50d22aa27752"
+  integrity sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==
   dependencies:
-    ip-address "^9.0.5"
+    ip-address "^10.1.1"
     smart-buffer "^4.2.0"
 
 sort-keys@^2.0.0:
@@ -4150,9 +4185,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.20"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz#e44ed19ed318dd1e5888f93325cee800f0f51b89"
-  integrity sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz#b069e687b1291a32f126893ed76a27a745ee2133"
+  integrity sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==
 
 split2@^3.2.2:
   version "3.2.2"
@@ -4167,11 +4202,6 @@ split@^1.0.1:
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
   dependencies:
     through "2"
-
-sprintf-js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
-  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -4191,9 +4221,9 @@ stackback@0.0.2:
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
 std-env@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
-  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -4251,11 +4281,11 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
     ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
-  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
-    ansi-regex "^6.0.1"
+    ansi-regex "^6.2.2"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4280,9 +4310,9 @@ strip-indent@^3.0.0:
     min-indent "^1.0.0"
 
 strip-literal@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.0.0.tgz#ce9c452a91a0af2876ed1ae4e583539a353df3fc"
-  integrity sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.1.0.tgz#222b243dd2d49c0bcd0de8906adbd84177196032"
+  integrity sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==
   dependencies:
     js-tokens "^9.0.1"
 
@@ -4327,13 +4357,13 @@ temp-dir@1.0.0:
   integrity sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==
 
 test-exclude@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.1.tgz#20b3ba4906ac20994e275bbcafd68d510264c2a2"
-  integrity sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.2.tgz#482392077630bc57d5630c13abe908bb910dfc65"
+  integrity sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==
   dependencies:
     "@istanbuljs/schema" "^0.1.2"
     glob "^10.4.1"
-    minimatch "^9.0.4"
+    minimatch "^10.2.2"
 
 text-extensions@^1.0.0:
   version "1.9.0"
@@ -4372,12 +4402,12 @@ tinyglobby@0.2.12:
     picomatch "^4.0.2"
 
 tinyglobby@^0.2.14, tinyglobby@^0.2.15:
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
-  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
   dependencies:
     fdir "^6.5.0"
-    picomatch "^4.0.3"
+    picomatch "^4.0.4"
 
 tinypool@^1.1.1:
   version "1.1.1"
@@ -4390,21 +4420,14 @@ tinyrainbow@^2.0.0:
   integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
 
 tinyspy@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.3.tgz#d1d0f0602f4c15f1aae083a34d6d0df3363b1b52"
-  integrity sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.4.tgz#d77a002fb53a88aa1429b419c1c92492e0c81f78"
+  integrity sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==
 
 tmp@~0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
-  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -4499,9 +4522,9 @@ typescript@5.9.2:
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
 
 "typescript@>=3 < 6":
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
-  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -4547,7 +4570,12 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@10.0.0, uuid@^10.0.0:
+uuid@14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.2.tgz#d5ae03e4db0881c87271f8b0b9bd7312d02c799a"
+  integrity sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==
+
+uuid@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
@@ -4582,11 +4610,11 @@ vite-node@3.2.4:
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
 
 "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.5.tgz#4dbcb48c6313116689be540466fc80faa377be38"
-  integrity sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.6.tgz#0547a395e68d3746e9a505f1fd4469fe09b49cc4"
+  integrity sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==
   dependencies:
-    esbuild "^0.25.0"
+    esbuild "^0.27.0 || ^0.28.0"
     fdir "^6.5.0"
     picomatch "^4.0.3"
     postcss "^8.5.6"
@@ -4778,9 +4806,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.6.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
-  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@21.1.1, yargs-parser@^21.1.1:
   version "21.1.1"
@@ -4792,7 +4820,7 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@17.7.2, yargs@^17.6.2:
+yargs@17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -4806,9 +4834,9 @@ yargs@17.7.2, yargs@^17.6.2:
     yargs-parser "^21.1.1"
 
 yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.2.tgz#c56731dca0d2788ae0866dd3c83907d6bab85f7d"
+  integrity sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"
@@ -4817,6 +4845,19 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.6.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
ObjectValidator allows defining custom `propertyOrder` and when it's is defined, missing optional properties that are not included in propertyOrder are fully skipped, resulting in significantly better performance for object types with many optional properties.

This PR also includes:
* uuid upgrade to fix CVE-2026-41907 vulnerability
* fixed  `anyOf` validator semantics
* improved error handling
* verified performance and memory footprint claims along with a benchmark suite to test custom datasets/validators.